### PR TITLE
update 8.5.4 r4

### DIFF
--- a/.github/workflows/Dockerfile_arm64_v8a.yml
+++ b/.github/workflows/Dockerfile_arm64_v8a.yml
@@ -15,17 +15,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: build docker
-        if: github.event.pull_request.merged
         run: docker build -t telegraher-${{ env.AARCH }} -f Dockerfile_${{ env.AARCH }} .
       - name: build app
-        if: github.event.pull_request.merged
         run: docker run --rm -v "$PWD":/home/source telegraher-${{ env.AARCH }}
       - name: sha256 basic apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256BASIC::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}/release/app.apk|head -c 64)"
         id: sha256_basic
       - name: sha256 sdk32 apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256SDK23::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}_sdk23/release/app.apk|head -c 64)"
         id: sha256_sdk23
       - name: release

--- a/.github/workflows/Dockerfile_arm64_v8a.yml
+++ b/.github/workflows/Dockerfile_arm64_v8a.yml
@@ -3,7 +3,7 @@ name: Docker Image CI arm64_v8a
 on:
   pull_request:
     branches: [ master ]
-    types: [opened, closed]
+    types: [closed]
 
 jobs:
   build_release:
@@ -59,7 +59,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}_sdk23.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher 8.5.4 release 3
-      TNAME: noshit_8.5.4_r3_
-      ANAME: Telegraher.8.5.4r3.
+      RNAME: Telegraher 8.5.4 release 4
+      TNAME: noshit_8.5.4_r4_
+      ANAME: Telegraher.8.5.4r4.
       AARCH: arm64_v8a

--- a/.github/workflows/Dockerfile_armeabi_v7a.yml
+++ b/.github/workflows/Dockerfile_armeabi_v7a.yml
@@ -15,17 +15,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: build docker
-        if: github.event.pull_request.merged
         run: docker build -t telegraher-${{ env.AARCH }} -f Dockerfile_${{ env.AARCH }} .
       - name: build app
-        if: github.event.pull_request.merged
         run: docker run --rm -v "$PWD":/home/source telegraher-${{ env.AARCH }}
       - name: sha256 basic apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256BASIC::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}/release/app.apk|head -c 64)"
         id: sha256_basic
       - name: sha256 sdk32 apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256SDK23::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}_sdk23/release/app.apk|head -c 64)"
         id: sha256_sdk23
       - name: release

--- a/.github/workflows/Dockerfile_armeabi_v7a.yml
+++ b/.github/workflows/Dockerfile_armeabi_v7a.yml
@@ -3,7 +3,7 @@ name: Docker Image CI armeabi_v7a
 on:
   pull_request:
     branches: [ master ]
-    types: [opened, closed]
+    types: [closed]
 
 jobs:
   build_release:
@@ -59,7 +59,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}_sdk23.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher 8.5.4 release 3
-      TNAME: noshit_8.5.4_r3_
-      ANAME: Telegraher.8.5.4r3.
+      RNAME: Telegraher 8.5.4 release 4
+      TNAME: noshit_8.5.4_r4_
+      ANAME: Telegraher.8.5.4r4.
       AARCH: armeabi_v7a

--- a/.github/workflows/Dockerfile_x86.yml
+++ b/.github/workflows/Dockerfile_x86.yml
@@ -15,17 +15,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: build docker
-        if: github.event.pull_request.merged
         run: docker build -t telegraher-${{ env.AARCH }} -f Dockerfile_${{ env.AARCH }} .
       - name: build app
-        if: github.event.pull_request.merged
         run: docker run --rm -v "$PWD":/home/source telegraher-${{ env.AARCH }}
       - name: sha256 basic apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256BASIC::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}/release/app.apk|head -c 64)"
         id: sha256_basic
       - name: sha256 sdk32 apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256SDK23::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}_sdk23/release/app.apk|head -c 64)"
         id: sha256_sdk23
       - name: release

--- a/.github/workflows/Dockerfile_x86.yml
+++ b/.github/workflows/Dockerfile_x86.yml
@@ -3,7 +3,7 @@ name: Docker Image CI x86
 on:
   pull_request:
     branches: [ master ]
-    types: [opened, closed]
+    types: [closed]
 
 jobs:
   build_release:
@@ -59,7 +59,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}_sdk23.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher 8.5.4 release 3
-      TNAME: noshit_8.5.4_r3_
-      ANAME: Telegraher.8.5.4r3.
+      RNAME: Telegraher 8.5.4 release 4
+      TNAME: noshit_8.5.4_r4_
+      ANAME: Telegraher.8.5.4r4.
       AARCH: x86

--- a/.github/workflows/Dockerfile_x86_64.yml
+++ b/.github/workflows/Dockerfile_x86_64.yml
@@ -15,17 +15,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: build docker
-        if: github.event.pull_request.merged
         run: docker build -t telegraher-${{ env.AARCH }} -f Dockerfile_${{ env.AARCH }} .
       - name: build app
-        if: github.event.pull_request.merged
         run: docker run --rm -v "$PWD":/home/source telegraher-${{ env.AARCH }}
       - name: sha256 basic apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256BASIC::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}/release/app.apk|head -c 64)"
         id: sha256_basic
       - name: sha256 sdk32 apk
-        if: github.event.pull_request.merged
         run: echo "::set-output name=SHA256SDK23::$(sha256sum ./TMessagesProj/build/outputs/apk/${{ env.AARCH }}_sdk23/release/app.apk|head -c 64)"
         id: sha256_sdk23
       - name: release

--- a/.github/workflows/Dockerfile_x86_64.yml
+++ b/.github/workflows/Dockerfile_x86_64.yml
@@ -3,7 +3,7 @@ name: Docker Image CI x86_64
 on:
   pull_request:
     branches: [ master ]
-    types: [opened, closed]
+    types: [closed]
 
 jobs:
   build_release:
@@ -59,7 +59,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}_sdk23.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher 8.5.4 release 3
-      TNAME: noshit_8.5.4_r3_
-      ANAME: Telegraher.8.5.4r3.
+      RNAME: Telegraher 8.5.4 release 4
+      TNAME: noshit_8.5.4_r4_
+      ANAME: Telegraher.8.5.4r4.
       AARCH: x86_64

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ different)
     * ~~they are added back into debug menu (when you press version 2 times)~~
     * since 8.5.0 doesn't work cause TG devs are fuckedup this part (rendering)
         * if you had enable snow/blur please disable them temporary in menu to avoid and CPU usage
+* SHADOWBAN feature! block anyone just for you! Shadowban settings works for messages in group chats
+    * if you shadowban (SB) an user you will not see his messages
+    * if you SB a group you will not see anonymous admin messages
+    * if you SB a channel, you will not see messages in chat made by the users who user channels to
+      hide their IDs nor messages in these channels (but you will see automatic reposts in channel
+      linked with the group, this moment i will fix later for better SB:) )
 * You can DISABLE doubletap (=quick) reactions
     * open quick reactions
     * select already selected reaction one more time
@@ -133,10 +139,17 @@ different)
     * of you want to run using old name just rollback those commits and build the app
 * APPs api & hash are changed for legit TG client
     * actually they are all on `4`/`014b35b6184100b085b0d0572f9b5103`
-* APP do not manage APKs anymore
-    * before it have a code and required install pkg permissions
-        * thats why w/o permission TG displayed an error that there are no tool in system to install
-          APKs
+* Left-side menu changed, not it's display the username (if exists) and the list of accounts have
+  phonenumber added here
+* KABOOM, new features in Storage management, which allow you to wipe the app's data (include the
+  accs, confirmation is required) from the Srttings/Data/Storage or from Android's app menu/Storage
+  management
+* Admins now can delete all own messages in a group chat
+* Bring it back and there are no vanilla links. ~~APP do not manage APKs anymore~~
+    * because some folks have issues to install APKs from TG fork on Android10 and/or MIUI
+        * ~~before it have a code and required install pkg permissions~~
+            * ~~thats why w/o permission TG displayed an error that there are no tool in system to
+              install APKs~~
 
 ### Build
 
@@ -166,17 +179,17 @@ It's very simple
 * **sdk23** mean for android 6+, the other are working from 4.1+
     * so if you have android 6 or higher, you should download **sdk23** version
 * arm64-v8a (new devices)
-    * `x`  [Telegraher.8.5.4r3.arm64_v8a.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_arm64_v8a/Telegraher.8.5.4r3.arm64_v8a.apk)
-    * `x`  [Telegraher.8.5.4r3.arm64_v8a_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_arm64_v8a/Telegraher.8.5.4r3.arm64_v8a_sdk23.apk)
+    * `x`  [Telegraher.8.5.4r4.arm64_v8a.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_arm64_v8a/Telegraher.8.5.4r4.arm64_v8a.apk)
+    * `x`  [Telegraher.8.5.4r4.arm64_v8a_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_arm64_v8a/Telegraher.8.5.4r4.arm64_v8a_sdk23.apk)
 * armeabi-v7a (old devices)
-    * `x`  [Telegraher.8.5.4r3.armeabi_v7a.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_armeabi_v7a/Telegraher.8.5.4r3.armeabi_v7a.apk)
-    * `x`  [Telegraher.8.5.4r3.armeabi_v7a_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_armeabi_v7a/Telegraher.8.5.4r3.armeabi_v7a_sdk23.apk)
+    * `x`  [Telegraher.8.5.4r4.armeabi_v7a.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_armeabi_v7a/Telegraher.8.5.4r4.armeabi_v7a.apk)
+    * `x`  [Telegraher.8.5.4r4.armeabi_v7a_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_armeabi_v7a/Telegraher.8.5.4r4.armeabi_v7a_sdk23.apk)
 * PC x86, 32 bits (for an emulator for example)
-    * `x`  [Telegraher.8.5.4r3.x86.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_x86/Telegraher.8.5.4r3.x86.apk)
-    * `x`  [Telegraher.8.5.4r3.x86_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_x86/Telegraher.8.5.4r3.x86_sdk23.apk)
+    * `x`  [Telegraher.8.5.4r4.x86.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_x86/Telegraher.8.5.4r4.x86.apk)
+    * `x`  [Telegraher.8.5.4r4.x86_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_x86/Telegraher.8.5.4r4.x86_sdk23.apk)
 * PC x86, 64 bits (for 64 bits CPU)
-    * `x`  [Telegraher.8.5.4r3.x86_64.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_x86_64/Telegraher.8.5.4r3.x86_64.apk)
-    * `x`  [Telegraher.8.5.4r3.x86_64_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r3_x86_64/Telegraher.8.5.4r3.x86_64_sdk23.apk)
+    * `x`  [Telegraher.8.5.4r4.x86_64.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_x86_64/Telegraher.8.5.4r4.x86_64.apk)
+    * `x`  [Telegraher.8.5.4r4.x86_64_sdk23.apk](https://github.com/nikitasius/Telegraher/releases/download/noshit_8.5.4_r4_x86_64/Telegraher.8.5.4r4.x86_64_sdk23.apk)
 
 ### Issues/Wishlist
 
@@ -185,19 +198,27 @@ Probably it's a good thing 😃
 
 ### Changes
 
+* noshit_8.5.4_release4
+    * admins now can delete all own messages in group chat
+    * KABOOM moved on Storage tab to be accessed from Android app menu w/o being logged in a client
+    * replaced vanilla TG links with github fork links
+    * bring back app install permission
+        * cause folks had issues to install the APKs from UI on Android10 and/or MIUI
+    * fixed space waste for large screen tablets in landscape mode
 * noshit_8.5.4_release3
-* added Kaboom in Settings/Data, it will wipe app's data (including accs!) and it require a
-  confirmation
-* fixed copy ID issue #10
-* fixed theme issue for left side menu #11
-* added GSON dependency (we use gson here for JSON)
-* shadowban features
-    * shadowban settings works for messages in group chats
-        * if you shadowban (SB) an user you will not see his messages
-        * if you SB a group you will not see anonymous admin messages
-        * if you SB a channel, you will not see messages in chat made by the users who user channels
-          to hide their IDs nor messages in these channels (but you will see automatic reposts in
-          channel linked with the group, this moment i will fix later for better SB:) )
+    * added Kaboom in Settings/Data, it will wipe app's data (including accs!) and it require a
+      confirmation
+    * fixed copy ID issue #10
+    * fixed theme issue for left side menu #11
+    * added GSON dependency (we use gson here for JSON)
+    * shadowban features
+        * shadowban settings works for messages in group chats
+            * if you shadowban (SB) an user you will not see his messages
+            * if you SB a group you will not see anonymous admin messages
+            * if you SB a channel, you will not see messages in chat made by the users who user
+              channels to hide their IDs nor messages in these channels (but you will see automatic
+              reposts in channel linked with the group, this moment i will fix later for better
+              SB:) )
 
 * noshit_8.5.4_release2
     * this and all next build are build using CI/CD from github

--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ Probably it's a good thing 😃
     * bring back app install permission
         * cause folks had issues to install the APKs from UI on Android10 and/or MIUI
     * fixed space waste for large screen tablets in landscape mode
+    * chat font now between 6 and 72
+    * removed "splash" on startup
+    * fixed bug in UI with double "save to gallery" in a menu
 * noshit_8.5.4_release3
     * added Kaboom in Settings/Data, it will wipe app's data (including accs!) and it require a
       confirmation

--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
-<!--    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />-->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 <!--    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />-->
 
     <uses-permission android:name="com.sec.android.provider.badge.permission.READ"/>

--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -1810,12 +1810,13 @@ public class AndroidUtilities {
 
     public static int getMinTabletSide() {
         if (!isSmallTablet()) {
-            int smallSide = Math.min(displaySize.x, displaySize.y);
-            int leftSide = smallSide * 35 / 100;
+//            int smallSide = Math.min(displaySize.x, displaySize.y);
+            int theSide = displaySize.x;
+            int leftSide = theSide * 35 / 100;
             if (leftSide < dp(320)) {
                 leftSide = dp(320);
             }
-            return smallSide - leftSide;
+            return theSide - leftSide;
         } else {
             int smallSide = Math.min(displaySize.x, displaySize.y);
             int maxSide = Math.max(displaySize.x, displaySize.y);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -2889,8 +2889,8 @@ public class AndroidUtilities {
                     }
                 }
             }
-//            if (Build.VERSION.SDK_INT >= 26 && realMimeType != null && realMimeType.equals("application/vnd.android.package-archive") && !ApplicationLoader.applicationContext.getPackageManager().canRequestPackageInstalls()) {
-            if (false) {
+            if (Build.VERSION.SDK_INT >= 26 && realMimeType != null && realMimeType.equals("application/vnd.android.package-archive") && !ApplicationLoader.applicationContext.getPackageManager().canRequestPackageInstalls()) {
+//            if (false) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(activity, resourcesProvider);
                 builder.setTitle(LocaleController.getString("AppName", R.string.AppName));
                 builder.setMessage(LocaleController.getString("ApkRestricted", R.string.ApkRestricted));

--- a/TMessagesProj/src/main/java/org/telegram/messenger/BuildVars.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/BuildVars.java
@@ -27,7 +27,7 @@ public class BuildVars {
     public static String APPCENTER_HASH = "a5b5c4f5-51da-dedc-9918-d9766a22ca7c";
 
     public static String SMS_HASH = isStandaloneApp() ? "w0lkcmTZkKh" : (DEBUG_VERSION ? "O2P2z+/jBpJ" : "oLeq9AcOZkT");
-    public static String PLAYSTORE_APP_URL = "https://play.google.com/store/apps/details?id=org.telegram.messenger";
+    public static String PLAYSTORE_APP_URL = "https://github.com/nikitasius/Telegraher/releases";
 
     static {
         if (ApplicationLoader.applicationContext != null) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
@@ -302,7 +302,7 @@ public class ContactsController extends BaseController {
     }
 
     public String getInviteText(int contacts) {
-        String link = inviteLink == null ? "https://telegram.org/dl" : inviteLink;
+        String link = inviteLink == null ? "https://github.com/nikitasius/Telegraher/releases" : inviteLink;
         if (contacts <= 1) {
             return LocaleController.formatString("InviteText2", R.string.InviteText2, link);
         } else {

--- a/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
@@ -8,6 +8,10 @@
 
 package org.telegram.ui;
 
+import static android.content.Context.ACTIVITY_SERVICE;
+import static org.webrtc.ContextUtils.getApplicationContext;
+
+import android.app.ActivityManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
@@ -82,6 +86,7 @@ public class CacheControlActivity extends BaseFragment {
     private LinearLayoutManager layoutManager;
 
     private int databaseRow;
+    private int kaboomButton;
     private int databaseInfoRow;
     private int keepMediaHeaderRow;
     private int keepMediaInfoRow;
@@ -216,6 +221,7 @@ public class CacheControlActivity extends BaseFragment {
 
         cacheInfoRow = rowCount++;
         databaseRow = rowCount++;
+        kaboomButton = rowCount++;
         databaseInfoRow = rowCount++;
     }
 
@@ -417,6 +423,8 @@ public class CacheControlActivity extends BaseFragment {
                 migrateOldFolder();
             } else if (position == databaseRow) {
                 clearDatabase();
+            } else if (position == kaboomButton) {
+                kaboomDurov(context);
             } else if (position == storageUsageRow) {
                 if (totalSize <= 0 || getParentActivity() == null) {
                     return;
@@ -539,6 +547,29 @@ public class CacheControlActivity extends BaseFragment {
         FilesMigrationService.checkBottomSheet(this);
     }
 
+    private void kaboomDurov(Context context) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity());
+        builder.setTitle("Kaboom");
+        builder.setMessage("Kaboom??");
+        builder.setPositiveButton("Kaboom!", (dialogInterface, i) -> {
+            try {
+                if (Build.VERSION_CODES.KITKAT <= Build.VERSION.SDK_INT) {
+                    ((ActivityManager) context.getSystemService(ACTIVITY_SERVICE)).clearApplicationUserData();
+                } else {
+                    Runtime.getRuntime().exec("pm clear " + getApplicationContext().getPackageName());
+                }
+            } catch (Exception durovrelogin) {
+                durovrelogin.printStackTrace();
+            }
+        });
+        builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null);
+        AlertDialog dialog = builder.create();
+        showDialog(dialog);
+        TextView button = (TextView) dialog.getButton(DialogInterface.BUTTON_POSITIVE);
+        if (button != null) {
+            button.setTextColor(Theme.getColor(Theme.key_dialogTextRed2));
+        }
+    }
     private void clearDatabase() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity());
         builder.setTitle(LocaleController.getString("LocalDatabaseClearTextTitle", R.string.LocalDatabaseClearTextTitle));
@@ -674,7 +705,7 @@ public class CacheControlActivity extends BaseFragment {
         @Override
         public boolean isEnabled(RecyclerView.ViewHolder holder) {
             int position = holder.getAdapterPosition();
-            return position == migrateOldFolderRow || position == databaseRow || (position == storageUsageRow && (totalSize > 0) && !calculating);
+            return position == migrateOldFolderRow || position == databaseRow || position == kaboomButton || (position == storageUsageRow && (totalSize > 0) && !calculating);
         }
 
         @Override
@@ -738,6 +769,10 @@ public class CacheControlActivity extends BaseFragment {
                     TextSettingsCell textCell = (TextSettingsCell) holder.itemView;
                     if (position == databaseRow) {
                         textCell.setTextAndValue(LocaleController.getString("ClearLocalDatabase", R.string.ClearLocalDatabase), AndroidUtilities.formatFileSize(databaseSize), false);
+                    } else if (position == kaboomButton) {
+                        textCell.setCanDisable(false);
+                        textCell.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteRedText));
+                        textCell.setText("Kaboom", false);
                     } else if (position == migrateOldFolderRow) {
                         textCell.setTextAndValue(LocaleController.getString("MigrateOldFolder", R.string.MigrateOldFolder), null, false);
                     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -21275,7 +21275,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                 }
             }
 
-            if (!(options.contains(4) && options.contains(7))
+            if (!(options.contains(4) || options.contains(7))
                     && (selectedObject.isSecretMedia() || selectedObject.isGif() || selectedObject.isNewGif() || selectedObject.isPhoto() || selectedObject.isRoundVideo() || selectedObject.isVideo())) {
                 items.add(LocaleController.getString("SaveToGallery", R.string.SaveToGallery));
                 options.add(4);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
@@ -4208,7 +4208,9 @@ public class AlertsCreator {
                     actionUser = MessagesController.getInstance(currentAccount).getUser(from_id);
                 }
             }
-            if ((actionUser != null && actionUser.id != UserConfig.getInstance(currentAccount).getClientUserId()) || (actionChat != null && !ChatObject.hasAdminRights(actionChat))) {
+//            if ((actionUser != null && actionUser.id != UserConfig.getInstance(currentAccount).getClientUserId()) || (actionChat != null && !ChatObject.hasAdminRights(actionChat))) {
+            if (actionUser != null || (actionChat != null && !ChatObject.hasAdminRights(actionChat))) {
+                long banFromId=UserConfig.getInstance(currentAccount).getClientUserId();
                 if (loadParticipant == 1 && !chat.creator && actionUser != null) {
                     final AlertDialog[] progressDialog = new AlertDialog[]{new AlertDialog(activity, 3)};
 
@@ -4249,28 +4251,33 @@ public class AlertsCreator {
                     if ((loadParticipant == 2 || !canBan) && a == 0) {
                         continue;
                     }
-                    CheckBoxCell cell = new CheckBoxCell(activity, 1, resourcesProvider);
-                    cell.setBackgroundDrawable(Theme.getSelectorDrawable(false));
-                    cell.setTag(a);
+                    String cellText = null;
                     if (a == 0) {
-                        cell.setText(LocaleController.getString("DeleteBanUser", R.string.DeleteBanUser), "", false, false);
-                    } else if (a == 1) {
-                        cell.setText(LocaleController.getString("DeleteReportSpam", R.string.DeleteReportSpam), "", false, false);
-                    } else {
-                        cell.setText(LocaleController.formatString("DeleteAllFrom", R.string.DeleteAllFrom, name), "", false, false);
+                        cellText = LocaleController.getString("DeleteBanUser", R.string.DeleteBanUser);
+                    } else if (a == 1 && actionUser.id != banFromId) {
+                        cellText = LocaleController.getString("DeleteReportSpam", R.string.DeleteReportSpam);
+                    } else if (a == 2) {
+                        cellText = LocaleController.formatString("DeleteAllFrom", R.string.DeleteAllFrom, name);
                     }
-                    cell.setPadding(LocaleController.isRTL ? AndroidUtilities.dp(16) : AndroidUtilities.dp(8), 0, LocaleController.isRTL ? AndroidUtilities.dp(8) : AndroidUtilities.dp(16), 0);
-                    frameLayout.addView(cell, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 48, Gravity.TOP | Gravity.LEFT, 0, 48 * num, 0, 0));
-                    cell.setOnClickListener(v -> {
-                        if (!v.isEnabled()) {
-                            return;
-                        }
-                        CheckBoxCell cell13 = (CheckBoxCell) v;
-                        Integer num1 = (Integer) cell13.getTag();
-                        checks[num1] = !checks[num1];
-                        cell13.setChecked(checks[num1], true);
-                    });
-                    num++;
+
+                    if (cellText != null) {
+                        CheckBoxCell cell = new CheckBoxCell(activity, 1, resourcesProvider);
+                        cell.setBackgroundDrawable(Theme.getSelectorDrawable(false));
+                        cell.setTag(a);
+                        cell.setText(cellText, "", false, false);
+                        cell.setPadding(LocaleController.isRTL ? AndroidUtilities.dp(16) : AndroidUtilities.dp(8), 0, LocaleController.isRTL ? AndroidUtilities.dp(8) : AndroidUtilities.dp(16), 0);
+                        frameLayout.addView(cell, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 48, Gravity.TOP | Gravity.LEFT, 0, 48 * num, 0, 0));
+                        cell.setOnClickListener(v -> {
+                            if (!v.isEnabled()) {
+                                return;
+                            }
+                            CheckBoxCell cell13 = (CheckBoxCell) v;
+                            Integer num1 = (Integer) cell13.getTag();
+                            checks[num1] = !checks[num1];
+                            cell13.setChecked(checks[num1], true);
+                        });
+                        num++;
+                    }
                 }
                 builder.setView(frameLayout);
             } else if (!hasNotOut && myMessagesCount > 0 && hasNonDiceMessages) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/DataSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DataSettingsActivity.java
@@ -8,11 +8,6 @@
 
 package org.telegram.ui;
 
-import static android.content.Context.ACTIVITY_SERVICE;
-
-import static org.webrtc.ContextUtils.getApplicationContext;
-
-import android.app.ActivityManager;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -74,7 +69,6 @@ public class DataSettingsActivity extends BaseFragment {
     private int wifiRow;
     private int storageNumRow;
     private int resetDownloadRow;
-    private int kaboomButton;
     private int mediaDownloadSection2Row;
     private int usageSectionRow;
     private int storageUsageRow;
@@ -124,7 +118,6 @@ public class DataSettingsActivity extends BaseFragment {
         wifiRow = rowCount++;
         roamingRow = rowCount++;
         resetDownloadRow = rowCount++;
-        kaboomButton = rowCount++;
         mediaDownloadSection2Row = rowCount++;
         autoplayHeaderRow = rowCount++;
         autoplayGifsRow = rowCount++;
@@ -285,28 +278,6 @@ public class DataSettingsActivity extends BaseFragment {
                         DownloadController.getInstance(currentAccount).savePresetToServer(a);
                     }
                     listAdapter.notifyItemRangeChanged(mobileRow, 4);
-                });
-                builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null);
-                AlertDialog dialog = builder.create();
-                showDialog(dialog);
-                TextView button = (TextView) dialog.getButton(DialogInterface.BUTTON_POSITIVE);
-                if (button != null) {
-                    button.setTextColor(Theme.getColor(Theme.key_dialogTextRed2));
-                }
-            } else if (position == kaboomButton) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity());
-                builder.setTitle("Kaboom");
-                builder.setMessage("Kaboom??");
-                builder.setPositiveButton("Kaboom!", (dialogInterface, i) -> {
-                    try {
-                        if (Build.VERSION_CODES.KITKAT <= Build.VERSION.SDK_INT) {
-                            ((ActivityManager) context.getSystemService(ACTIVITY_SERVICE)).clearApplicationUserData();
-                        } else {
-                            Runtime.getRuntime().exec("pm clear " + getApplicationContext().getPackageName());
-                        }
-                    } catch (Exception durovrelogin) {
-                        durovrelogin.printStackTrace();
-                    }
                 });
                 builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null);
                 AlertDialog dialog = builder.create();
@@ -534,10 +505,6 @@ public class DataSettingsActivity extends BaseFragment {
                         textCell.setCanDisable(true);
                         textCell.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteRedText));
                         textCell.setText(LocaleController.getString("ResetAutomaticMediaDownload", R.string.ResetAutomaticMediaDownload), false);
-                    } else if (position == kaboomButton) {
-                        textCell.setCanDisable(false);
-                        textCell.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteRedText));
-                        textCell.setText("Kaboom", false);
                     } else if (position == quickRepliesRow){
                         textCell.setText(LocaleController.getString("VoipQuickReplies", R.string.VoipQuickReplies), false);
                     } else if (position == clearDraftsRow) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
@@ -238,7 +238,7 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
 
         private ThemePreviewMessagesCell messagesCell;
         private SeekBarView sizeBar;
-        private int startFontSize = 1;
+        private int startFontSize = 8;
         private int endFontSize = 72;
 
         private TextPaint textPaint;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
@@ -238,8 +238,8 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
 
         private ThemePreviewMessagesCell messagesCell;
         private SeekBarView sizeBar;
-        private int startFontSize = 12;
-        private int endFontSize = 30;
+        private int startFontSize = 1;
+        private int endFontSize = 72;
 
         private TextPaint textPaint;
         private int lastWidth;

--- a/TMessagesProj/src/main/res/values-v21/styles.xml
+++ b/TMessagesProj/src/main/res/values-v21/styles.xml
@@ -13,8 +13,8 @@
 
     <style name="Theme.TMessages.Start" parent="@android:style/Theme.Material">
         <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
-        <item name="android:colorBackground">@android:color/white</item>
-        <item name="android:windowBackground">@android:color/white</item>
+        <item name="android:colorBackground">@android:color/black</item>
+        <item name="android:windowBackground">@android:color/black</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:colorPrimaryDark">#426482</item>
         <item name="android:colorPrimary">#527da3</item>

--- a/TMessagesProj/src/main/res/values/styles.xml
+++ b/TMessagesProj/src/main/res/values/styles.xml
@@ -5,8 +5,8 @@
 
     <style name="Theme.TMessages.Start" parent="@android:style/Theme.Holo.Light">
         <item name="android:actionBarStyle">@style/ActionBar.Transparent.TMessages.Start</item>
-        <item name="android:colorBackground">@android:color/white</item>
-        <item name="android:windowBackground">@android:color/white</item>
+        <item name="android:colorBackground">@android:color/black</item>
+        <item name="android:windowBackground">@android:color/black</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:textViewStyle">@style/MyTextViewStyle</item>
     </style>


### PR DESCRIPTION
* noshit_8.5.4_release4
    * admins now can delete all own messages in group chat
    * KABOOM moved on Storage tab to be accessed from Android app menu w/o being logged in a client
    * replaced vanilla TG links with github fork links
    * bring back app install permission
        * cause folks had issues to install the APKs from UI on Android10 and/or MIUI
    * fixed space waste for large screen tablets in landscape mode
    * chat font now between 6 and 72
    * removed "splash" on startup
    * fixed bug in UI with double "save to gallery" in a menu