### PR TITLE
beta 8.85.39

### DIFF
--- a/.github/workflows/Dockerfile_bundle.yml
+++ b/.github/workflows/Dockerfile_bundle.yml
@@ -44,7 +44,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher BETA 8.85.38
-      TNAME: noshit_8.85.38_
-      ANAME: Telegraher.BETA.8.85.38.
+      RNAME: Telegraher BETA 8.85.39
+      TNAME: noshit_8.85.39_
+      ANAME: Telegraher.BETA.8.85.39.
       AARCH: bundle

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ different)
     * [armeabi_v7a](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.74.6_armeabi_v7a)
     * [x86](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.74.6_x86)
     * [x86_64](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.74.6_x86_64)
-* Last beta `8.85.37`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.37_bundle)
+* Last beta `8.85.39`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.39_bundle)
 
 ### Issues/Wishlist
 

--- a/README_CHANGES.md
+++ b/README_CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+* 8.85.39
+    * well we disable journal_mode
+        * i don't see any good moments on a telegram app except files which growing up. There are no rollbacks, app just
+          select/insert/delete the data. So now it's off. Lets see how it will work on mass tests.
+    * SM now show internal accountIds
+    * before `Reset session manager & device spoofing` now `SYNC session manager & RESET device spoofing` in a debug
+      menu
+    * added Disable spoilers
 * 8.85.38
     * you can choose XXX as your message notification icon also
     * added to debug menu wipe ALL message history for actual account

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -211,7 +211,7 @@ android {
     }
 //    2636001 mean 2636 0 01 where 2636 is vanilla code version, and 01 is the release one
 //    defaultConfig.versionCode = 2721
-    defaultConfig.versionCode = 2725038
+    defaultConfig.versionCode = 2725039
 
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
@@ -230,7 +230,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionName "8.85.38"
+        versionName "8.85.39"
 
         vectorDrawables.generatedDensities = ['mdpi', 'hdpi', 'xhdpi', 'xxhdpi']
 

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
@@ -101,6 +101,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
     private int chatSBManagerRow;
     private int chatSwapToNextChannelRow;
     private int chatTabsOnForwardRow;
+    private int chatDisableSpoilersRow;
 
     private int videoLabelRoundBitrateRow;
     private int videoRoundBitrateMultRow;
@@ -177,6 +178,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
         chatSBManagerRow = rowCount++;
         chatSwapToNextChannelRow = rowCount++;
         chatTabsOnForwardRow = rowCount++;
+        chatDisableSpoilersRow = rowCount++;
 
         accountLabelRow = rowCount++;
         accountSessionManagerRow = rowCount++;
@@ -335,6 +337,12 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                 SharedPreferences.Editor editor = preferences.edit();
                 enabled = preferences.getBoolean("EnableTabsOnForward", false);
                 editor.putBoolean("EnableTabsOnForward", !enabled);
+                editor.apply();
+            } else if (position == chatDisableSpoilersRow) {
+                SharedPreferences preferences = MessagesController.getGlobalTelegraherSettings();
+                SharedPreferences.Editor editor = preferences.edit();
+                enabled = preferences.getBoolean("DisableSpoilers", false);
+                editor.putBoolean("DisableSpoilers", !enabled);
                 editor.apply();
             } else if (position == accountExtendVanillaRow) {
                 SharedPreferences preferences = MessagesController.getGlobalTelegraherSettings();
@@ -597,6 +605,8 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THEnableSwapToNextChannel), globalPreps.getBoolean("EnableSwapToNextChannel", false), true);
                     } else if (position == chatTabsOnForwardRow) {
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THEnableTabsOnForward), globalPreps.getBoolean("EnableTabsOnForward", false), true);
+                    } else if (position == chatDisableSpoilersRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString(R.string.THDisableSpoilers), globalPreps.getBoolean("DisableSpoilers", false), true);
                     } else if (position == gifHDRow) {
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THEnableGifHD), globalPreps.getBoolean("EnableGifHD", false), true);
                     } else if (position == videoRoundUseMainCameraRow) {
@@ -807,7 +817,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                             || position == voipHDRow || position == voipDisableStartBeep || position == voipDisableEndBeep
                             || position == profileUIDRow || position == profileDCIDRow || position == profileSBRow
                             || position == hardwareDisableVibroRow
-                            || position == chatDeleteMarkRow || position == chatEnableMessageHistoryRow || position == accountExtendVanillaRow || position == chatSBFullRow || position == chatSwapToNextChannelRow || position == chatTabsOnForwardRow
+                            || position == chatDeleteMarkRow || position == chatEnableMessageHistoryRow || position == accountExtendVanillaRow || position == chatSBFullRow || position == chatSwapToNextChannelRow || position == chatTabsOnForwardRow || position == chatDisableSpoilersRow
                             || position == graheriumSpeedUp || position == graheriumAnimateEveryAvatar || position == graheriumAnimatedStickerOverlays || position == graheriumVanillaStickerFlow
                             || position == gifHDRow || position == videoRoundUseMainCameraRow
                             || position == uiAppHidePhoneNumberOnLeftPanelRow

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/session/ThSessionManagerActivity.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/session/ThSessionManagerActivity.java
@@ -270,7 +270,8 @@ public class ThSessionManagerActivity extends BaseFragment implements Notificati
                                         thTextDetailCell.isChecked() ? EMOJIS[1] : EMOJIS[0],
                                         SharedConfig.thAccounts.get(accs.get(position)).get("userPhone").toString())
                                 ,
-                                String.format(Locale.US, "%s %s(@%s) - %s %s, SDK (%s)"
+                                String.format(Locale.US, "%d: %s %s(@%s) - %s %s, SDK (%s)"
+                                        , accs.get(position)
                                         , SharedConfig.thAccounts.get(accs.get(position)).get("userFName")
                                         , SharedConfig.thAccounts.get(accs.get(position)).get("userLName")
                                         , SharedConfig.thAccounts.get(accs.get(position)).get("userName")

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -10667,7 +10667,7 @@ public class MessagesStorage extends BaseController {
     }
 
     public List<Long> markMessagesAsIsDeleted(Long dialogId, ArrayList<Integer> messages, boolean useQueue) {
-        if (messages.isEmpty()) {
+        if (messages == null || messages.isEmpty()) {
             return null;
         }
         if (useQueue) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -265,7 +265,7 @@ public class MessagesStorage extends BaseController {
             database = new SQLiteDatabase(cacheFile.getPath());
             database.executeFast("PRAGMA secure_delete = ON").stepThis().dispose();
             database.executeFast("PRAGMA temp_store = MEMORY").stepThis().dispose();
-            database.executeFast("PRAGMA journal_mode = WAL").stepThis().dispose();
+            database.executeFast("PRAGMA journal_mode = OFF").stepThis().dispose();
             database.executeFast("PRAGMA journal_size_limit = 10485760").stepThis().dispose();
 
             if (createTable) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/spoilers/SpoilerEffect.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/spoilers/SpoilerEffect.java
@@ -38,11 +38,7 @@ import androidx.annotation.Nullable;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.math.MathUtils;
 
-import org.telegram.messenger.AndroidUtilities;
-import org.telegram.messenger.Emoji;
-import org.telegram.messenger.LocaleController;
-import org.telegram.messenger.SharedConfig;
-import org.telegram.messenger.Utilities;
+import org.telegram.messenger.*;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.Easings;
 import org.telegram.ui.Components.TextStyleSpan;
@@ -591,6 +587,7 @@ public class SpoilerEffect extends Drawable {
      * @param spoilers     Spoilers list to populate
      */
     public static void addSpoilers(@Nullable View v, Layout textLayout, @Nullable Stack<SpoilerEffect> spoilersPool, List<SpoilerEffect> spoilers) {
+        if (MessagesController.getGlobalTelegraherSettings().getBoolean("DisableSpoilers", false)) return;
         if (textLayout.getText() instanceof Spanned){
             addSpoilers(v, textLayout, (Spanned) textLayout.getText(), spoilersPool, spoilers);
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -2985,7 +2985,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                                 LocaleController.getString(SharedConfig.forceRtmpStream ? R.string.DebugMenuDisableForceRtmpStreamFlag : R.string.DebugMenuEnableForceRtmpStreamFlag),
                                 LocaleController.getString(R.string.DebugMenuClearWebViewCache) ,
                                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ? LocaleController.getString(SharedConfig.debugWebView ? R.string.DebugMenuDisableWebViewDebug : R.string.DebugMenuEnableWebViewDebug) : null,
-                                "Reset session manager & device spoofing",
+                                "SYNC session manager & RESET device spoofing",
                                 "WIPE message history data"
                         };
                         builder.setItems(items, (dialog, which) -> {

--- a/TMessagesProj/src/main/res/values-ru/strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings.xml
@@ -69,6 +69,7 @@
     <string name="THUIUseCustomFontDummy">(%s)</string>
     <string name="THEnableSwapToNextChannel">Следующий канал при свайпе</string>
     <string name="THEnableTabsOnForward">Вкладки при пересылке</string>
+    <string name="THDisableSpoilers">Выключить спойлеры</string>
     <string name="ThIdCopied">ID скопирован в буфер</string>
     <string name="ThDCCopied">DC скопирован в буфер</string>
     <string name="THChatSBManager">Shadowban менеджер</string>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5519,6 +5519,7 @@
     <string name="THUIUseCustomFontDummy">(%s)</string>
     <string name="THEnableSwapToNextChannel">Next channel on swap</string>
     <string name="THEnableTabsOnForward">Tabs on forward</string>
+    <string name="THDisableSpoilers">Disable spoilers</string>
     <string name="ThIdCopied">ID copied to clipboard</string>
     <string name="ThDCCopied">DC copied to clipboard</string>
     <string name="THChatSBManager">Shadowban manager</string>


### PR DESCRIPTION
* fixed null crash for message history
* well we disable journal_mode
i don't see any good moments on a telegram app except files which growing up. There are no rollbacks, app just select/insert/delete the data. So now it's off. Lets see how it will work on mass tests.
* SM now show internal accountIds
* before `Reset session manager & device spoofing` now `SYNC session manager & RESET device spoofing` in a debug menu
* added Disable spoilers