### PR TITLE
Release Telegraher 8.85.40

### DIFF
--- a/.github/workflows/Dockerfile_bundle.yml
+++ b/.github/workflows/Dockerfile_bundle.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: build docker
-        run: docker build -t telegraher-${{ env.AARCH }} -f Dockerfile_${{ env.AARCH }} --build-arg SIGNING_KEY_ALIAS --build-arg SIGNING_KEY_PASSWORD --build-arg SIGNING_STORE_PASSWORD .
+        run: docker build -t telegraher-${{ env.AARCH }} -f Dockerfile_${{ env.AARCH }} --build-arg RELEASE_KEY_PASSWORD --build-arg RELEASE_KEY_ALIAS --build-arg RELEASE_STORE_PASSWORD .
         env:
-          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
       - name: build app
         run: docker run --rm -v "$PWD":/home/source telegraher-${{ env.AARCH }}
       - name: sha256 basic apk


### PR DESCRIPTION
well trying to pass our own keys to CI/CD
The point is that release will be signed with our own keys we keep private.
The reason:
- once installed from github CI/CD app can be updated only with an another apk signed with same keys

Why it's useful? well, if someone want to fake our client and say "folks here is graher 9.0.1" it won't upgrade actual client.

The examples:
- TG app have own keys
- Fdroid release have own (=fdroid) keys.

Btw, about fdroid: we will run own repo which will be added to fdroid app by user. Apk will be built on github actions.

So.. lets try to build it now:
github ci/cd -> pass to docker -> pass to gradle. Hope it will work :)



This release will have `com.evildayz.code.telegraher2` package name, so you will be able to move accs from 8.7.x to 8.8.x manually (using both apps) before deleting 8.7.x.


## upd: env variables are fixed