### PR TITLE
Release 8.85.46

### DIFF
--- a/.github/workflows/Dockerfile_bundle.yml
+++ b/.github/workflows/Dockerfile_bundle.yml
@@ -45,7 +45,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher 8.85.45
-      TNAME: noshit_8.85.45_
-      ANAME: Telegraher.8.85.45.
+      RNAME: Telegraher 8.85.46
+      TNAME: noshit_8.85.46_
+      ANAME: Telegraher.8.85.46.
       AARCH: bundle

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ different)
 * Realeases are
   here: [https://github.com/nikitasius/Telegraher/releases](https://github.com/nikitasius/Telegraher/releases)
     * if it contain `beta` it mean it's BETA
-* Last release `8.85.45`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.45_bundle)
+* Last release `8.85.46`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.46_bundle)
 * Last beta `8.85.39`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.39_bundle)
 
 ### Issues/Wishlist

--- a/README_CHANGES.md
+++ b/README_CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+* 8.85.46
+    * "clear db" is disabled cause we need to rework vanilla code (we don't use journal/wal)
+    * "delete downloaded file" also works for videos & music
+    * history message now use default font size from the app
+        * default for dates, `-2` for the texts
+    * you can change sticker size now: x0.25, x0.5, x1 & x2
+    * you can enable real forwarded message time
+    * you can hide stickers in chats
+        * alpha version, they are still in cache, still takes place in ui (just a white element)
+        * but they are not rendered :)
 * 8.85.45
     * we compress libs, so APK should be smaller, but installation longer.
         * "Gplay optimisations failed"? well we're not on gplay.

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -211,7 +211,7 @@ android {
     }
 //    2636001 mean 2636 0 01 where 2636 is vanilla code version, and 01 is the release one
 //    defaultConfig.versionCode = 2721
-    defaultConfig.versionCode = 2725045
+    defaultConfig.versionCode = 2725046
 
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
@@ -230,7 +230,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionName "8.85.45"
+        versionName "8.85.46"
 
         vectorDrawables.generatedDensities = ['mdpi', 'hdpi', 'xhdpi', 'xxhdpi']
 

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
@@ -107,6 +107,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
     private int chatSwapToNextChannelRow;
     private int chatTabsOnForwardRow;
     private int chatDisableSpoilersRow;
+    private int chatRealForwardedMessageTimeRow;
 
     private int videoLabelRoundBitrateRow;
     private int videoRoundBitrateMultRow;
@@ -192,6 +193,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
         chatSwapToNextChannelRow = rowCount++;
         chatTabsOnForwardRow = rowCount++;
         chatDisableSpoilersRow = rowCount++;
+        chatRealForwardedMessageTimeRow = rowCount++;
 
         accountLabelRow = rowCount++;
         accountSessionManagerRow = rowCount++;
@@ -365,6 +367,12 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                 SharedPreferences.Editor editor = preferences.edit();
                 enabled = preferences.getBoolean("DisableSpoilers", false);
                 editor.putBoolean("DisableSpoilers", !enabled);
+                editor.apply();
+            } else if (position == chatRealForwardedMessageTimeRow) {
+                SharedPreferences preferences = MessagesController.getGlobalTelegraherSettings();
+                SharedPreferences.Editor editor = preferences.edit();
+                enabled = preferences.getBoolean("RealForwardedMessageTime", true);
+                editor.putBoolean("RealForwardedMessageTime", !enabled);
                 editor.apply();
             } else if (position == accountExtendVanillaRow) {
                 SharedPreferences preferences = MessagesController.getGlobalTelegraherSettings();
@@ -645,6 +653,8 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THEnableTabsOnForward), globalPreps.getBoolean("EnableTabsOnForward", false), true);
                     } else if (position == chatDisableSpoilersRow) {
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THDisableSpoilers), globalPreps.getBoolean("DisableSpoilers", false), true);
+                    } else if (position == chatRealForwardedMessageTimeRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString(R.string.THChatRealForwardedMessageTime), globalPreps.getBoolean("RealForwardedMessageTime", true), true);
                     } else if (position == gifHDRow) {
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THEnableGifHD), globalPreps.getBoolean("EnableGifHD", false), true);
                     } else if (position == videoRoundUseMainCameraRow) {
@@ -888,7 +898,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                             || position == privacyDontCallAppleRow
                             || position == profileUIDRow || position == profileDCIDRow || position == profileSBRow
                             || position == hardwareDisableVibroRow
-                            || position == chatDeleteMarkRow || position == chatEnableMessageHistoryRow || position == accountExtendVanillaRow || position == chatSBFullRow || position == chatSwapToNextChannelRow || position == chatTabsOnForwardRow || position == chatDisableSpoilersRow
+                            || position == chatDeleteMarkRow || position == chatEnableMessageHistoryRow || position == accountExtendVanillaRow || position == chatSBFullRow || position == chatSwapToNextChannelRow || position == chatTabsOnForwardRow || position == chatDisableSpoilersRow|| position == chatRealForwardedMessageTimeRow
                             || position == graheriumSpeedUpUpload || position == graheriumSpeedUpDownload || position == graheriumAnimateEveryAvatar || position == graheriumAnimatedStickerOverlays || position == graheriumVanillaStickerFlow
                             || position == gifHDRow || position == videoRoundUseMainCameraRow
                             || position == uiAppHidePhoneNumberOnLeftPanelRow

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
@@ -77,6 +77,8 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
     private int uiLabelRow;
     private int uiAppNotificationIconRow;
     private int uiAppNotificationIconSelectorRow;
+    private int uiStickerSizeLabelRow;
+    private int uiStickerSizeRow;
     private int uiAppHidePhoneNumberOnLeftPanelRow;
     private int uiSystemFontRegularRow;
     private int uiSystemFontBoldRow;
@@ -151,6 +153,8 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
         uiLabelRow = rowCount++;
         uiAppNotificationIconRow = rowCount++;
         uiAppNotificationIconSelectorRow = rowCount++;
+        uiStickerSizeLabelRow = rowCount++;
+        uiStickerSizeRow = rowCount++;
         uiAppHidePhoneNumberOnLeftPanelRow = rowCount++;
         uiSystemFontRegularRow = -1;//TODO WTF need the fuck make it work
         uiSystemFontBoldRow = -1;
@@ -548,6 +552,8 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                         headerCell.setText(LocaleController.getString(R.string.THUILabelRow));
                     } else if (position == uiAppNotificationIconRow) {
                         headerCell.setText(LocaleController.getString(R.string.THUIAppNotificationIconRow));
+                    } else if (position == uiStickerSizeLabelRow) {
+                        headerCell.setText(LocaleController.getString(R.string.THUIStickerSize));
                     } else if (position == voiceLabelRow) {
                         headerCell.setText(LocaleController.getString(R.string.THVoiceLabelRow));
                     } else if (position == voipLabelRow) {
@@ -786,6 +792,23 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                                 editor.apply();
                             }
                         });
+                    } else if (position == uiStickerSizeRow) {
+                        String[] strings = new String[]{
+                                "x0.25",
+                                "x0.5",
+                                "x1",
+                                "x2",
+                        };
+                        slideChooseView.setOptions(MessagesController.getGlobalTelegraherSettings().getInt("UIStickerSize", 2), strings);
+                        slideChooseView.setCallback(new SlideChooseView.Callback() {
+                            @Override
+                            public void onOptionSelected(int index) {
+                                SharedPreferences globalTh = MessagesController.getGlobalTelegraherSettings();
+                                SharedPreferences.Editor editor = globalTh.edit();
+                                editor.putInt("UIStickerSize", index);
+                                editor.apply();
+                            }
+                        });
                     } else if (position == graheriumStarrMark) {
                         String[] strings = new String[]{LocaleController.getString(R.string.THGraheriumStarrNoone), LocaleController.getString(R.string.THGraheriumStarrEveryone), LocaleController.getString(R.string.THGraheriumStarrPeperemiumOnly)};
                         slideChooseView.setOptions(MessagesController.getGlobalTelegraherSettings().getInt("GraheriumStarrMark", 0), strings);
@@ -840,6 +863,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                     position == showLabelTelegraherMenuRow
                             || position == uiLabelRow
                             || position == uiAppNotificationIconRow
+                            || position == uiStickerSizeLabelRow
                             || position == voiceLabelRow || position == voipLabelRow
                             || position == privacyLabelRow
                             || position == profileLabelRow
@@ -880,6 +904,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                             || position == videoMaxResolutionRow
                             || position == hardwareProximitySensorModeRow
                             || position == uiAppNotificationIconSelectorRow
+                            || position == uiStickerSizeRow
                             || position == graheriumStarrMark
                             || position == graheriumOverrideConnectionSpeed
             ) {

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/TelegraherSettingsActivity.java
@@ -108,6 +108,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
     private int chatTabsOnForwardRow;
     private int chatDisableSpoilersRow;
     private int chatRealForwardedMessageTimeRow;
+    private int chatHideStickersRow;
 
     private int videoLabelRoundBitrateRow;
     private int videoRoundBitrateMultRow;
@@ -194,6 +195,7 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
         chatTabsOnForwardRow = rowCount++;
         chatDisableSpoilersRow = rowCount++;
         chatRealForwardedMessageTimeRow = rowCount++;
+        chatHideStickersRow = rowCount++;
 
         accountLabelRow = rowCount++;
         accountSessionManagerRow = rowCount++;
@@ -373,6 +375,12 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                 SharedPreferences.Editor editor = preferences.edit();
                 enabled = preferences.getBoolean("RealForwardedMessageTime", true);
                 editor.putBoolean("RealForwardedMessageTime", !enabled);
+                editor.apply();
+            } else if (position == chatHideStickersRow) {
+                SharedPreferences preferences = MessagesController.getGlobalTelegraherSettings();
+                SharedPreferences.Editor editor = preferences.edit();
+                enabled = preferences.getBoolean("HideStickers", false);
+                editor.putBoolean("HideStickers", !enabled);
                 editor.apply();
             } else if (position == accountExtendVanillaRow) {
                 SharedPreferences preferences = MessagesController.getGlobalTelegraherSettings();
@@ -655,6 +663,8 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THDisableSpoilers), globalPreps.getBoolean("DisableSpoilers", false), true);
                     } else if (position == chatRealForwardedMessageTimeRow) {
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THChatRealForwardedMessageTime), globalPreps.getBoolean("RealForwardedMessageTime", true), true);
+                    } else if (position == chatHideStickersRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString(R.string.THChatHideStickers), globalPreps.getBoolean("HideStickers", false), true);
                     } else if (position == gifHDRow) {
                         checkCell.setTextAndCheck(LocaleController.getString(R.string.THEnableGifHD), globalPreps.getBoolean("EnableGifHD", false), true);
                     } else if (position == videoRoundUseMainCameraRow) {
@@ -898,7 +908,9 @@ public class TelegraherSettingsActivity extends BaseFragment implements Notifica
                             || position == privacyDontCallAppleRow
                             || position == profileUIDRow || position == profileDCIDRow || position == profileSBRow
                             || position == hardwareDisableVibroRow
-                            || position == chatDeleteMarkRow || position == chatEnableMessageHistoryRow || position == accountExtendVanillaRow || position == chatSBFullRow || position == chatSwapToNextChannelRow || position == chatTabsOnForwardRow || position == chatDisableSpoilersRow|| position == chatRealForwardedMessageTimeRow
+                            || position == chatDeleteMarkRow || position == chatEnableMessageHistoryRow || position == accountExtendVanillaRow || position == chatSBFullRow
+                            || position == chatSwapToNextChannelRow || position == chatTabsOnForwardRow || position == chatDisableSpoilersRow || position == chatRealForwardedMessageTimeRow
+                            || position == chatHideStickersRow
                             || position == graheriumSpeedUpUpload || position == graheriumSpeedUpDownload || position == graheriumAnimateEveryAvatar || position == graheriumAnimatedStickerOverlays || position == graheriumVanillaStickerFlow
                             || position == gifHDRow || position == videoRoundUseMainCameraRow
                             || position == uiAppHidePhoneNumberOnLeftPanelRow

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/ThMessageHistoryActivity.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/ThMessageHistoryActivity.java
@@ -244,6 +244,8 @@ public class ThMessageHistoryActivity extends BaseFragment implements Notificati
                     if (false) {
                         //durov relogin!
                     } else if (position >= 0 && position < messageMap.size()) {
+                        thTextDetailCell.setTitleFontSize(SharedConfig.fontSize);
+                        thTextDetailCell.setValueFontSize(SharedConfig.fontSize - 2);
                         thTextDetailCell.setTextAndValue(
                                 LocaleController.formatDateAudio(messageMap.get(position).date, false)
                                 , new String(android.util.Base64.decode(messageMap.get(position).message, Base64.DEFAULT))

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/ThePenisMightierThanTheSword.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/ThePenisMightierThanTheSword.java
@@ -155,4 +155,18 @@ public class ThePenisMightierThanTheSword {
                 return bool;
         }
     }
+
+    public static float stickerSizeMult() {
+        switch (MessagesController.getGlobalTelegraherSettings().getInt("UIStickerSize", 2)) {
+            case 0:
+                return 4f;
+            case 1:
+                return 2f;
+            case 3:
+                return 0.5f;
+            case 2:
+            default:
+                return 1f;
+        }
+    }
 }

--- a/TMessagesProj/src/main/java/com/evildayz/code/telegraher/ui/ThTextDetailCell.java
+++ b/TMessagesProj/src/main/java/com/evildayz/code/telegraher/ui/ThTextDetailCell.java
@@ -102,6 +102,14 @@ public class ThTextDetailCell extends FrameLayout {
         );
     }
 
+    public void setTitleFontSize(int fontSize) {
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, fontSize);
+    }
+
+    public void setValueFontSize(int fontSize) {
+        valueTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, fontSize);
+    }
+
     public void setTextAndValue(String text, String value, boolean divider) {
         textView.setText(text);
         valueTextView.setText(value);

--- a/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
@@ -61,13 +61,7 @@ import org.telegram.ui.Cells.HeaderCell;
 import org.telegram.ui.Cells.TextCheckBoxCell;
 import org.telegram.ui.Cells.TextInfoPrivacyCell;
 import org.telegram.ui.Cells.TextSettingsCell;
-import org.telegram.ui.Components.CubicBezierInterpolator;
-import org.telegram.ui.Components.LayoutHelper;
-import org.telegram.ui.Components.RecyclerListView;
-import org.telegram.ui.Components.SlideChooseView;
-import org.telegram.ui.Components.StorageDiagramView;
-import org.telegram.ui.Components.StroageUsageView;
-import org.telegram.ui.Components.UndoView;
+import org.telegram.ui.Components.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -636,11 +630,13 @@ public class CacheControlActivity extends BaseFragment implements NotificationCe
             if (getParentActivity() == null) {
                 return;
             }
-            progressDialog = new AlertDialog(getParentActivity(), 3);
-            progressDialog.setCanCancel(false);
-            progressDialog.showDelayed(500);
-            MessagesController.getInstance(currentAccount).clearQueryTime();
-            getMessagesStorage().clearLocalDatabase();
+//            progressDialog = new AlertDialog(getParentActivity(), 3);
+//            progressDialog.setCanCancel(false);
+//            progressDialog.showDelayed(500);
+            // disabled until we will find a good way for that.
+            BulletinFactory.of(this).createCopyBulletin(LocaleController.getString(R.string.PopupDisabled), parentLayout.getLastFragment().getResourceProvider()).show();
+//            MessagesController.getInstance(currentAccount).clearQueryTime();
+//            getMessagesStorage().clearLocalDatabase();
         });
         AlertDialog alertDialog = builder.create();
         showDialog(alertDialog);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -73,6 +73,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.core.graphics.ColorUtils;
 
+import com.evildayz.code.telegraher.ThePenisMightierThanTheSword;
 import org.telegram.PhoneFormat.PhoneFormat;
 import org.telegram.messenger.AccountInstance;
 import org.telegram.messenger.AndroidUtilities;
@@ -5887,22 +5888,23 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         maxHeight = maxWidth = (int) (Math.min(getParentWidth(), AndroidUtilities.displaySize.y) * 0.5f);
                     }
                     String filter;
-                    if (messageObject.isAnimatedEmoji() || messageObject.isDice()) {
-                        float zoom = MessagesController.getInstance(currentAccount).animatedEmojisZoom;
-                        photoWidth = (int) ((photoWidth / 512.0f) * maxWidth * zoom);
-                        photoHeight = (int) ((photoHeight / 512.0f) * maxHeight * zoom);
-                    } else {
-                        if (photoWidth == 0) {
-                            photoHeight = (int) maxHeight;
-                            photoWidth = photoHeight + AndroidUtilities.dp(100);
-                        }
-                        photoHeight *= maxWidth / (float) photoWidth;
-                        photoWidth = (int) maxWidth;
-                        if (photoHeight > maxHeight) {
-                            photoWidth *= maxHeight / photoHeight;
-                            photoHeight = (int) maxHeight;
-                        }
+//                    if (messageObject.isAnimatedEmoji() || messageObject.isDice()) {
+//                        float zoom = MessagesController.getInstance(currentAccount).animatedEmojisZoom;
+//                        photoWidth = (int) ((photoWidth / 512.0f) * maxWidth * zoom);
+//                        photoHeight = (int) ((photoHeight / 512.0f) * maxHeight * zoom);
+//                    } else {
+                    if (photoWidth == 0) {
+                        photoHeight = (int) maxHeight;
+                        photoWidth = photoHeight + AndroidUtilities.dp(100);
                     }
+                    photoHeight *= maxWidth / (float) photoWidth;
+                    photoHeight /= ThePenisMightierThanTheSword.stickerSizeMult();
+                    photoWidth = (int) (maxWidth / ThePenisMightierThanTheSword.stickerSizeMult());
+                    if (photoHeight > maxHeight) {
+                        photoWidth *= maxHeight / photoHeight;
+                        photoHeight = (int) maxHeight;
+                    }
+                    //}
                     Object parentObject = messageObject;
                     int w = (int) (photoWidth / AndroidUtilities.density);
                     int h = (int) (photoHeight / AndroidUtilities.density);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -5861,7 +5861,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                         additionHeight += reactionsLayoutInBubble.totalHeight;
                     }
-                } else if (messageObject.isAnyKindOfSticker()) {
+                } else if (!MessagesController.getGlobalTelegraherSettings().getBoolean("HideStickers", false) && messageObject.isAnyKindOfSticker()) {
                     drawBackground = false;
                     boolean isWebpSticker = messageObject.type == MessageObject.TYPE_STICKER;
                     for (int a = 0; a < messageObject.getDocument().attributes.size(); a++) {
@@ -5984,7 +5984,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         additionHeight += reactionsLayoutInBubble.totalHeight;
                         reactionsLayoutInBubble.positionOffsetY += AndroidUtilities.dp(4);
                     }
-                } else {
+                } else if (!messageObject.isAnyKindOfSticker()) {
                     currentPhotoObject = FileLoader.getClosestPhotoSizeWithSize(messageObject.photoThumbs, AndroidUtilities.getPhotoSize());
                     photoParentObject = messageObject.photoThumbsObject;
                     boolean useFullWidth = false;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -10928,6 +10928,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     currentForwardNameString = currentForwardName;
                 }
 
+                if (MessagesController.getGlobalTelegraherSettings().getBoolean("RealForwardedMessageTime", true))
+                    currentForwardNameString += String.format(" %s", LocaleController.formatDateAudio(messageObject.messageOwner.fwd_from.date, false));
+
                 forwardedNameWidth = getMaxNameWidth();
                 String forwardedString = getForwardedMessageText(messageObject);
                 if (hasPsaHint) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -21574,7 +21574,7 @@ ChatActivity extends BaseFragment implements NotificationCenter.NotificationCent
                 icons.add(R.drawable.msg_log);
             }
 
-            if (message != null && (message.isDocument() || message.isVideo())) {
+            if (message != null && (message.isDocument() || message.isVideo() || message.isMusic())) {
                 items.add(LocaleController.getString(R.string.THDDeleteDownloadedFile));
                 options.add(420_002);
                 icons.add(R.drawable.msg_delete_filled);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -21574,7 +21574,7 @@ ChatActivity extends BaseFragment implements NotificationCenter.NotificationCent
                 icons.add(R.drawable.msg_log);
             }
 
-            if (message != null && message.isDocument()) {
+            if (message != null && (message.isDocument() || message.isVideo())) {
                 items.add(LocaleController.getString(R.string.THDDeleteDownloadedFile));
                 options.add(420_002);
                 icons.add(R.drawable.msg_delete_filled);

--- a/TMessagesProj/src/main/java/org/telegram/ui/SuggestClearDatabaseBottomSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SuggestClearDatabaseBottomSheet.java
@@ -19,6 +19,7 @@ import org.telegram.ui.ActionBar.AlertDialog;
 import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ActionBar.BottomSheet;
 import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Components.BulletinFactory;
 import org.telegram.ui.Components.LayoutHelper;
 import org.telegram.ui.Components.StickerImageView;
 
@@ -85,8 +86,10 @@ public class SuggestClearDatabaseBottomSheet extends BottomSheet {
                 if (fragment.getParentActivity() == null) {
                     return;
                 }
-                MessagesController.getInstance(currentAccount).clearQueryTime();
-                fragment.getMessagesStorage().clearLocalDatabase();
+                // disabled until we will find a good way for that.
+                BulletinFactory.of(fragment).createCopyBulletin(LocaleController.getString(R.string.PopupDisabled), fragment.getResourceProvider()).show();
+//                MessagesController.getInstance(currentAccount).clearQueryTime();
+//                fragment.getMessagesStorage().clearLocalDatabase();
             });
             AlertDialog alertDialog = builder.create();
             fragment.showDialog(alertDialog);

--- a/TMessagesProj/src/main/res/values-ar/strings.xml
+++ b/TMessagesProj/src/main/res/values-ar/strings.xml
@@ -4582,4 +4582,5 @@
     <string name="THGraheriumOverrideConnectionSpeedSlow">بطيء</string>
     <string name="THGraheriumOverrideConnectionSpeedHigh">سريع</string>
     <string name="THPrivacyDontCallApple">لا تستخدم طلبات Apple</string>
+    <string name="THUIStickerSize">حجم الملصق</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-ar/strings.xml
+++ b/TMessagesProj/src/main/res/values-ar/strings.xml
@@ -4583,4 +4583,5 @@
     <string name="THGraheriumOverrideConnectionSpeedHigh">سريع</string>
     <string name="THPrivacyDontCallApple">لا تستخدم طلبات Apple</string>
     <string name="THUIStickerSize">حجم الملصق</string>
+    <string name="THChatRealForwardedMessageTime">الوقت الحقيقي للرسائل المعاد توجيهها</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-ar/strings.xml
+++ b/TMessagesProj/src/main/res/values-ar/strings.xml
@@ -4584,4 +4584,5 @@
     <string name="THPrivacyDontCallApple">لا تستخدم طلبات Apple</string>
     <string name="THUIStickerSize">حجم الملصق</string>
     <string name="THChatRealForwardedMessageTime">الوقت الحقيقي للرسائل المعاد توجيهها</string>
+    <string name="THChatHideStickers">إخفاء الملصقات في المحادثات</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-ru/strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings.xml
@@ -103,4 +103,5 @@
     <string name="THGraheriumOverrideConnectionSpeedHigh">Высокая</string>
     <string name="THPrivacyRowLabel">Секция приватности</string>
     <string name="THPrivacyDontCallApple">Не использовать Apple</string>
+    <string name="THUIStickerSize">Размер стикеров</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-ru/strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings.xml
@@ -104,4 +104,5 @@
     <string name="THPrivacyRowLabel">Секция приватности</string>
     <string name="THPrivacyDontCallApple">Не использовать Apple</string>
     <string name="THUIStickerSize">Размер стикеров</string>
+    <string name="THChatRealForwardedMessageTime">Настоящее время пересланного сообщения</string>
 </resources>

--- a/TMessagesProj/src/main/res/values-ru/strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings.xml
@@ -105,4 +105,5 @@
     <string name="THPrivacyDontCallApple">Не использовать Apple</string>
     <string name="THUIStickerSize">Размер стикеров</string>
     <string name="THChatRealForwardedMessageTime">Настоящее время пересланного сообщения</string>
+    <string name="THChatHideStickers">Скрывать стикеры в чатах</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5553,4 +5553,5 @@
     <string name="THGraheriumOverrideConnectionSpeedHigh">Fast</string>
     <string name="THPrivacyRowLabel">Privacy section</string>
     <string name="THPrivacyDontCallApple">Don\'t use Apple</string>
+    <string name="THUIStickerSize">Sticker size</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5554,4 +5554,5 @@
     <string name="THPrivacyRowLabel">Privacy section</string>
     <string name="THPrivacyDontCallApple">Don\'t use Apple</string>
     <string name="THUIStickerSize">Sticker size</string>
+    <string name="THChatRealForwardedMessageTime">Real forwarded message time</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -5555,4 +5555,5 @@
     <string name="THPrivacyDontCallApple">Don\'t use Apple</string>
     <string name="THUIStickerSize">Sticker size</string>
     <string name="THChatRealForwardedMessageTime">Real forwarded message time</string>
+    <string name="THChatHideStickers">Hide stickers in chats</string>
 </resources>


### PR DESCRIPTION
* "clear db" is disabled cause we need to rework vanilla code (we don't use journal/wal)
* "delete downloaded file" also works for videos & music
* history message now use default font size from the app
* default for dates, `-2` for the texts
* you can change sticker size now: x0.25, x0.5, x1 & x2
* you can enable real forwarded message time
* you can hide stickers in chats
   * alpha version, they are still in cache, still takes place in ui (just a white element)
   * but they are not rendered :)