### PR TITLE
release 8.85.49

### DIFF
--- a/.github/workflows/Dockerfile_bundle.yml
+++ b/.github/workflows/Dockerfile_bundle.yml
@@ -45,7 +45,7 @@ jobs:
           asset_name: ${{ env.ANAME }}${{ env.AARCH }}.apk
           asset_content_type: application/gzip
     env:
-      RNAME: Telegraher 8.85.48
-      TNAME: noshit_8.85.48_
-      ANAME: Telegraher.8.85.48.
+      RNAME: Telegraher 8.85.49
+      TNAME: noshit_8.85.49_
+      ANAME: Telegraher.8.85.49.
       AARCH: bundle

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ different)
 * Realeases are
   here: [https://github.com/nikitasius/Telegraher/releases](https://github.com/nikitasius/Telegraher/releases)
     * if it contain `beta` it mean it's BETA
-* Last release `8.85.48`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.48_bundle)
+* Last release `8.85.49`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/noshit_8.85.49_bundle)
 * Last beta: write `!beta` in chat
 
 ### Issues/Wishlist

--- a/README_CHANGES.md
+++ b/README_CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+* 8.85.49
+    * app use data from BuildVars everywhere
+    * login flow looks now pretty legit for me
 * 8.85.48
     * bit changed login part
     * .gitignore fix

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -211,7 +211,7 @@ android {
     }
 //    2636001 mean 2636 0 01 where 2636 is vanilla code version, and 01 is the release one
 //    defaultConfig.versionCode = 2721
-    defaultConfig.versionCode = 2725048
+    defaultConfig.versionCode = 2725049
 
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
@@ -230,7 +230,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionName "8.85.48"
+        versionName "8.85.49"
 
         vectorDrawables.generatedDensities = ['mdpi', 'hdpi', 'xhdpi', 'xxhdpi']
 

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -68,7 +68,7 @@ public class ApplicationLoader extends Application {
     public static boolean canDrawOverlays;
     public static volatile long mainInterfacePausedStageQueueTime;
 
-    public static boolean hasPlayServices;
+    public static boolean hasPlayServices = true;
 
     @Override
     protected void attachBaseContext(Context base) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/BuildVars.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/BuildVars.java
@@ -21,12 +21,15 @@ public class BuildVars {
     public static boolean CHECK_UPDATES = true;
     public static boolean NO_SCOPED_STORAGE = Build.VERSION.SDK_INT <= 29;
     public static int BUILD_VERSION = 2725;
+    public static int BUILD_VERSION_FULL = 27252;
+    public static String BUILD_VENDOR = "com.android.vending";
+    public static String BUILD_DUROV = "org.telegram.messenger";
     public static String BUILD_VERSION_STRING = "8.8.6";
     public static int APP_ID = 4;
     public static String APP_HASH = "014b35b6184100b085b0d0572f9b5103";
     public static String APPCENTER_HASH = "a5b5c4f5-51da-dedc-9918-d9766a22ca7c";
 
-    public static String SMS_HASH = isStandaloneApp() ? "w0lkcmTZkKh" : (DEBUG_VERSION ? "O2P2z+/jBpJ" : "oLeq9AcOZkT");
+    public static String SMS_HASH = "oLeq9AcOZkT";
     public static String PLAYSTORE_APP_URL = "https://github.com/nikitasius/Telegraher/releases";
 
     // You can use this flag to disable Google Play Billing (If you're making fork and want it to be in Google Play)
@@ -40,22 +43,16 @@ public class BuildVars {
     }
 
     public static boolean useInvoiceBilling() {
-        return DEBUG_VERSION || isStandaloneApp() || isBetaApp();
+        return false;
     }
 
     private static Boolean standaloneApp;
     public static boolean isStandaloneApp() {
-        if (standaloneApp == null) {
-            standaloneApp = ApplicationLoader.applicationContext != null && "org.telegram.messenger.web".equals(ApplicationLoader.applicationContext.getPackageName());
-        }
-        return standaloneApp;
+        return false;
     }
 
     private static Boolean betaApp;
     public static boolean isBetaApp() {
-        if (betaApp == null) {
-            betaApp = ApplicationLoader.applicationContext != null && "org.telegram.messenger.beta".equals(ApplicationLoader.applicationContext.getPackageName());
-        }
-        return betaApp;
+        return false;
     }
 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
@@ -327,7 +327,7 @@ public class ContactsController extends BaseController {
         if (true) return;
         AccountManager am = AccountManager.get(ApplicationLoader.applicationContext);
         try {
-            Account[] accounts = am.getAccountsByType("org.telegram.messenger");
+            Account[] accounts = am.getAccountsByType(BuildVars.BUILD_DUROV);
             systemAccount = null;
             for (int a = 0; a < accounts.length; a++) {
                 Account acc = accounts[a];
@@ -360,7 +360,7 @@ public class ContactsController extends BaseController {
             readContacts();
             if (systemAccount == null) {
                 try {
-                    systemAccount = new Account("" + getUserConfig().getClientUserId(), "org.telegram.messenger");
+                    systemAccount = new Account("" + getUserConfig().getClientUserId(), BuildVars.BUILD_DUROV);
                     am.addAccountExplicitly(systemAccount, "", null);
                 } catch (Exception ignore) {
 
@@ -374,7 +374,7 @@ public class ContactsController extends BaseController {
         try {
             systemAccount = null;
             AccountManager am = AccountManager.get(ApplicationLoader.applicationContext);
-            Account[] accounts = am.getAccountsByType("org.telegram.messenger");
+            Account[] accounts = am.getAccountsByType(BuildVars.BUILD_DUROV);
             for (int a = 0; a < accounts.length; a++) {
                 Account acc = accounts[a];
                 boolean found = false;
@@ -451,7 +451,7 @@ public class ContactsController extends BaseController {
                     if (false) {
                         AccountManager am = AccountManager.get(ApplicationLoader.applicationContext);
                         try {
-                            Account[] accounts = am.getAccountsByType("org.telegram.messenger");
+                            Account[] accounts = am.getAccountsByType(BuildVars.BUILD_DUROV);
                             systemAccount = null;
                             for (int a = 0; a < accounts.length; a++) {
                                 Account acc = accounts[a];
@@ -469,7 +469,7 @@ public class ContactsController extends BaseController {
 
                         }
                         try {
-                            systemAccount = new Account("" + getUserConfig().getClientUserId(), "org.telegram.messenger");
+                            systemAccount = new Account("" + getUserConfig().getClientUserId(), BuildVars.BUILD_DUROV);
                             am.addAccountExplicitly(systemAccount, "", null);
                         } catch (Exception ignore) {
 
@@ -1848,7 +1848,7 @@ public class ContactsController extends BaseController {
                 settings.edit().putBoolean("contacts_updated_v7", true).apply();
             }
             final ContentResolver contentResolver = ApplicationLoader.applicationContext.getContentResolver();
-            Uri rawContactUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()).appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_TYPE, "org.telegram.messenger").build();
+            Uri rawContactUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()).appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_TYPE, BuildVars.BUILD_DUROV).build();
             cursor = contentResolver.query(rawContactUri, new String[]{BaseColumns._ID, ContactsContract.RawContacts.SYNC2}, null, null, null);
             LongSparseArray<Long> bookContacts = new LongSparseArray<>();
             if (cursor != null) {
@@ -2054,7 +2054,7 @@ public class ContactsController extends BaseController {
         ContentResolver contentResolver = ApplicationLoader.applicationContext.getContentResolver();
         if (check) {
             try {
-                Uri rawContactUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()).appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_TYPE, "org.telegram.messenger").build();
+                Uri rawContactUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()).appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_TYPE, BuildVars.BUILD_DUROV).build();
                 int value = contentResolver.delete(rawContactUri, ContactsContract.RawContacts.SYNC2 + " = " + user.id, null);
             } catch (Exception ignore) {
 
@@ -2065,7 +2065,7 @@ public class ContactsController extends BaseController {
 
         ContentProviderOperation.Builder builder = ContentProviderOperation.newInsert(ContactsContract.RawContacts.CONTENT_URI);
         builder.withValue(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString());
-        builder.withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, "org.telegram.messenger");
+        builder.withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, BuildVars.BUILD_DUROV);
         builder.withValue(ContactsContract.RawContacts.SYNC1, TextUtils.isEmpty(user.phone) ? "" : user.phone);
         builder.withValue(ContactsContract.RawContacts.SYNC2, user.id);
         query.add(builder.build());
@@ -2136,7 +2136,7 @@ public class ContactsController extends BaseController {
         }
         try {
             ContentResolver contentResolver = ApplicationLoader.applicationContext.getContentResolver();
-            Uri rawContactUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()).appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_TYPE, "org.telegram.messenger").build();
+            Uri rawContactUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()).appendQueryParameter(ContactsContract.RawContacts.ACCOUNT_TYPE, BuildVars.BUILD_DUROV).build();
             int value = contentResolver.delete(rawContactUri, ContactsContract.RawContacts.SYNC2 + " = " + uid, null);
         } catch (Exception e) {
             FileLog.e(e);
@@ -2539,7 +2539,7 @@ public class ContactsController extends BaseController {
             // 1. Check if we already have the invisible group/label and create it if we don't
             Cursor cursor = resolver.query(groupsURI, new String[]{ContactsContract.Groups._ID},
                     ContactsContract.Groups.TITLE + "=? AND " + ContactsContract.Groups.ACCOUNT_TYPE + "=? AND " + ContactsContract.Groups.ACCOUNT_NAME + "=?",
-                    new String[]{"TelegramConnectionService", "org.telegram.messenger", Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()}, null);
+                    new String[]{"TelegramConnectionService", BuildVars.BUILD_DUROV, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()}, null);
             int groupID;
             if (cursor != null && cursor.moveToFirst()) {
                 groupID = cursor.getInt(0);
@@ -2549,7 +2549,7 @@ public class ContactsController extends BaseController {
                         .build());*/
             } else {
                 ContentValues values = new ContentValues();
-                values.put(ContactsContract.Groups.ACCOUNT_TYPE, "org.telegram.messenger");
+                values.put(ContactsContract.Groups.ACCOUNT_TYPE, BuildVars.BUILD_DUROV);
                 values.put(ContactsContract.Groups.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString());
                 values.put(ContactsContract.Groups.GROUP_VISIBLE, 0);
                 values.put(ContactsContract.Groups.GROUP_IS_READ_ONLY, 1);
@@ -2584,7 +2584,7 @@ public class ContactsController extends BaseController {
                         .build());
             } else {
                 ops.add(ContentProviderOperation.newInsert(rawContactsURI)
-                        .withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, "org.telegram.messenger")
+                        .withValue(ContactsContract.RawContacts.ACCOUNT_TYPE, BuildVars.BUILD_DUROV)
                         .withValue(ContactsContract.RawContacts.ACCOUNT_NAME, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString())
                         .withValue(ContactsContract.RawContacts.RAW_CONTACT_IS_READ_ONLY, 1)
                         .withValue(ContactsContract.RawContacts.AGGREGATION_MODE, ContactsContract.RawContacts.AGGREGATION_MODE_DISABLED)
@@ -2625,7 +2625,7 @@ public class ContactsController extends BaseController {
 
             Cursor cursor = resolver.query(ContactsContract.Groups.CONTENT_URI, new String[]{ContactsContract.Groups._ID},
                     ContactsContract.Groups.TITLE + "=? AND " + ContactsContract.Groups.ACCOUNT_TYPE + "=? AND " + ContactsContract.Groups.ACCOUNT_NAME + "=?",
-                    new String[]{"TelegramConnectionService", "org.telegram.messenger", Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()}, null);
+                    new String[]{"TelegramConnectionService", BuildVars.BUILD_DUROV, Long.valueOf(UserConfig.getInstance(currentAccount).getClientUserId()).toString()}, null);
             int groupID;
             if (cursor != null && cursor.moveToFirst()) {
                 groupID = cursor.getInt(0);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/FileRefController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/FileRefController.java
@@ -418,7 +418,7 @@ public class FileRefController extends BaseController {
             } else if ("update".equals(string)) {
                 TLRPC.TL_help_getAppUpdate req = new TLRPC.TL_help_getAppUpdate();
                 try {
-                    req.source = "com.android.vending";
+                    req.source = BuildVars.BUILD_VENDOR;
                 } catch (Exception ignore) {
 
                 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/RefererReceiver.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/RefererReceiver.java
@@ -15,7 +15,7 @@ import android.content.Intent;
 public class RefererReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         try {
-            MessagesController.getInstance(UserConfig.selectedAccount).setReferer("com.android.vending");
+            MessagesController.getInstance(UserConfig.selectedAccount).setReferer(BuildVars.BUILD_VENDOR);
         } catch (Exception ignore) {
 
         }

--- a/TMessagesProj/src/main/java/org/telegram/tgnet/ConnectionsManager.java
+++ b/TMessagesProj/src/main/java/org/telegram/tgnet/ConnectionsManager.java
@@ -190,8 +190,7 @@ public class ConnectionsManager extends BaseController {
             systemLangCode = LocaleController.getSystemLocaleStringIso639().toLowerCase();
             langCode = LocaleController.getLocaleStringIso639().toLowerCase();
             deviceModel = SharedConfig.thDeviceSpoofing.get(id).get("deviceBrand") + SharedConfig.thDeviceSpoofing.get(id).get("deviceModel");
-            PackageInfo pInfo = ApplicationLoader.applicationContext.getPackageManager().getPackageInfo(ApplicationLoader.applicationContext.getPackageName(), 0);
-            appVersion = BuildVars.BUILD_VERSION_STRING + " (" + (pInfo.versionCode / 100) + ")";
+            appVersion = BuildVars.BUILD_VERSION_STRING + " (" + (BuildVars.BUILD_VERSION_FULL) + ")";
             if (BuildVars.DEBUG_PRIVATE_VERSION) {
                 appVersion += " pbeta";
             } else if (BuildVars.DEBUG_VERSION) {
@@ -399,8 +398,8 @@ public class ConnectionsManager extends BaseController {
         if (preferences.getBoolean("proxy_enabled", false) && !TextUtils.isEmpty(proxyAddress)) {
             native_setProxySettings(currentAccount, proxyAddress, proxyPort, proxyUsername, proxyPassword, proxySecret);
         }
-        String installer = "com.android.vending";
-        String packageId = "org.telegram.messenger";
+        String installer = BuildVars.BUILD_VENDOR;
+        String packageId = BuildVars.BUILD_DUROV;
 
         native_init(currentAccount, version, layer, apiId, deviceModel, systemVersion, appVersion, langCode, systemLangCode, configPath, logPath, regId, cFingerprint, installer, packageId, timezoneOffset, userId, enablePushConnection, ApplicationLoader.isNetworkOnline(), ApplicationLoader.getCurrentNetworkType());
         checkConnection();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/BlockingUpdateView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/BlockingUpdateView.java
@@ -25,17 +25,8 @@ import android.widget.TextView;
 
 import androidx.core.content.FileProvider;
 
-import org.telegram.messenger.AndroidUtilities;
-import org.telegram.messenger.ApplicationLoader;
+import org.telegram.messenger.*;
 import org.telegram.messenger.BuildConfig;
-import org.telegram.messenger.FileLoader;
-import org.telegram.messenger.FileLog;
-import org.telegram.messenger.LocaleController;
-import org.telegram.messenger.MessageObject;
-import org.telegram.messenger.NotificationCenter;
-import org.telegram.messenger.R;
-import org.telegram.messenger.SharedConfig;
-import org.telegram.messenger.UserConfig;
 import org.telegram.messenger.browser.Browser;
 import org.telegram.tgnet.ConnectionsManager;
 import org.telegram.tgnet.TLRPC;
@@ -336,7 +327,7 @@ public class BlockingUpdateView extends FrameLayout implements NotificationCente
         if (check) {
             TLRPC.TL_help_getAppUpdate req = new TLRPC.TL_help_getAppUpdate();
             try {
-                req.source = "com.android.vending";
+                req.source = BuildVars.BUILD_VENDOR;
             } catch (Exception ignore) {
 
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -1592,7 +1592,7 @@ public class LoginActivity extends BaseFragment {
         private boolean ignoreOnTextChange = false;
         private boolean ignoreOnPhoneChange = false;
         private boolean nextPressed = false;
-        private boolean confirmedNumber = false;
+        private boolean confirmedNumber = true;
 
         public PhoneView(Context context) {
             super(context);
@@ -2355,6 +2355,11 @@ public class LoginActivity extends BaseFragment {
             boolean allowReadCallLog = true;
             boolean allowReadPhoneNumbers = true;
 
+            SharedPreferences pref = MessagesController.getGlobalMainSettings();
+            if (pref.getBoolean("firstlogin", true)) {
+                pref.edit().putBoolean("firstlogin", false).apply();
+            }
+
             if (false) {
                 allowCall = getParentActivity().checkSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
                 allowCancelCall = getParentActivity().checkSelfPermission(Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED;
@@ -2583,16 +2588,19 @@ public class LoginActivity extends BaseFragment {
             needShowProgress(reqId);
         }
 
-        private boolean numberFilled;
+        private boolean numberFilled = true;
         public void fillNumber() {
+            if (true) return;
+            //this code never played
             if (numberFilled || activityMode != MODE_LOGIN) {
                 return;
             }
             try {
+                TelephonyManager tm = (TelephonyManager) ApplicationLoader.applicationContext.getSystemService(Context.TELEPHONY_SERVICE);
                 if (AndroidUtilities.isSimAvailable()) {
                     boolean allowCall = true;
                     boolean allowReadPhoneNumbers = true;
-                    if (false) {
+                    if (Build.VERSION.SDK_INT >= 23) {
                         allowCall = getParentActivity().checkSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                             allowReadPhoneNumbers = getParentActivity().checkSelfPermission(Manifest.permission.READ_PHONE_NUMBERS) == PackageManager.PERMISSION_GRANTED;
@@ -2635,10 +2643,8 @@ public class LoginActivity extends BaseFragment {
                     if (!newAccount && allowCall && allowReadPhoneNumbers) {
                         codeField.setAlpha(0);
                         phoneField.setAlpha(0);
-//                        String number = PhoneFormat.stripExceptNumbers(tm.getLine1Number());
-//                        String number = PhoneFormat.stripExceptNumbers(codeField.getText().toString());
-                        String number = PhoneFormat.stripExceptNumbers("+" + codeField.getText() + phoneField.getText());
-//                        String number = PhoneFormat.stripExceptNumbers(tm.getLine1Number());
+
+                        String number = PhoneFormat.stripExceptNumbers(tm.getLine1Number());
                         String textToSet = null;
                         boolean ok = false;
                         if (!TextUtils.isEmpty(number)) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -1033,8 +1033,7 @@ public class LoginActivity extends BaseFragment {
         }
         builder.setNeutralButton(LocaleController.getString("BotHelp", R.string.BotHelp), (dialog, which) -> {
             try {
-                PackageInfo pInfo = ApplicationLoader.applicationContext.getPackageManager().getPackageInfo(ApplicationLoader.applicationContext.getPackageName(), 0);
-                String version = String.format(Locale.US, "%s (%d)", BuildVars.BUILD_VERSION_STRING, pInfo.versionCode / 100);
+                String version = String.format(Locale.US, "%s (%d)", BuildVars.BUILD_VERSION_STRING, BuildVars.BUILD_VERSION_FULL);
 
                 Intent mailer = new Intent(Intent.ACTION_SENDTO);
                 mailer.setData(Uri.parse("mailto:"));
@@ -3063,8 +3062,7 @@ public class LoginActivity extends BaseFragment {
                             .setMessage(AndroidUtilities.replaceTags(LocaleController.formatString("DidNotGetTheCodeInfo", R.string.DidNotGetTheCodeInfo, phone)))
                             .setNeutralButton(LocaleController.getString(R.string.DidNotGetTheCodeHelpButton), (dialog, which)->{
                                 try {
-                                    PackageInfo pInfo = ApplicationLoader.applicationContext.getPackageManager().getPackageInfo(ApplicationLoader.applicationContext.getPackageName(), 0);
-                                    String version = String.format(Locale.US, "%s (%d)", BuildVars.BUILD_VERSION_STRING, pInfo.versionCode / 100);
+                                    String version = String.format(Locale.US, "%s (%d)", BuildVars.BUILD_VERSION_STRING, BuildVars.BUILD_VERSION_FULL);
 
                                     Intent mailer = new Intent(Intent.ACTION_SENDTO);
                                     mailer.setData(Uri.parse("mailto:"));

--- a/TMessagesProj/src/main/java/org/telegram/ui/PassportActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PassportActivity.java
@@ -7362,8 +7362,7 @@ public class PassportActivity extends BaseFragment implements NotificationCenter
                     resendCode();
                 } else {
                     try {
-                        PackageInfo pInfo = ApplicationLoader.applicationContext.getPackageManager().getPackageInfo(ApplicationLoader.applicationContext.getPackageName(), 0);
-                        String version = String.format(Locale.US, "%s (%d)", BuildVars.BUILD_VERSION_STRING, pInfo.versionCode / 100);
+                        String version = String.format(Locale.US, "%s (%d)", BuildVars.BUILD_VERSION_STRING, BuildVars.BUILD_VERSION_FULL);
 
                         Intent mailer = new Intent(Intent.ACTION_SENDTO);
                         mailer.setData(Uri.parse("mailto:"));

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -7596,10 +7596,9 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                     cell.getTextView().setTextColor(getThemedColor(Theme.key_windowBackgroundWhiteGrayText3));
                     cell.getTextView().setMovementMethod(null);
                     try {
-                        PackageInfo pInfo = ApplicationLoader.applicationContext.getPackageManager().getPackageInfo(ApplicationLoader.applicationContext.getPackageName(), 0);
-                        int code = pInfo.versionCode / 1000;
+                        int code = BuildVars.BUILD_VERSION;
                         String abi = "";
-                        switch ((pInfo.versionCode / 100) % 10) {
+                        switch (BuildVars.BUILD_VERSION_FULL % 10) {
                             case 1:
                             case 2:
                                 abi = "store bundled " + Build.CPU_ABI + " " + Build.CPU_ABI2;
@@ -7613,7 +7612,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                                 }
                                 break;
                         }
-                        cell.setText(LocaleController.formatString("TelegramVersion", R.string.TelegramVersion, String.format(Locale.US, "v%s (%d) %s", pInfo.versionName, code, abi)));
+                        cell.setText(LocaleController.formatString("TelegramVersion", R.string.TelegramVersion, String.format(Locale.US, "v%s (%d) %s", BuildVars.BUILD_VERSION_STRING, code, abi)));
                     } catch (Exception e) {
                         FileLog.e(e);
                     }


### PR DESCRIPTION
* app use data from BuildVars everywhere
* login flow looks now pretty legit for me


Also:
* some folks on exotic ROMs mostly from HUAWEI facing the issue with graher, "you app is too old"
* you will face same issue from Huawei if you will use official 8.8.5 or 8.8.6 bundles
* the solution:
  * go to app properties of freshly installed graher
  * go to storage management
  * go to graher menu
  * spoof your device from Huawai to `Xiaomi`/`MI MIX 2`/`30` (30 is for the OS)
  * kill the app
  * start the app and add the account
  * it's worked fine for folks who had that issue on huawei.
  * MORE devices you can find here http://deviceinfohw.ru/devices/item.php?item=565947 , just DON'T use Huawei!