### PR TITLE
Telegraher 9.33.18

### DIFF
--- a/.github/workflows/Dockerfile_bundle.yml
+++ b/.github/workflows/Dockerfile_bundle.yml
@@ -45,7 +45,7 @@ jobs:
                     asset_name: ${{ env.ANAME }}${{ env.AARCH }}.apk
                     asset_content_type: application/gzip
         env:
-            RNAME: Telegraher 9.33.17
-            TNAME: graher_9.33.17_
-            ANAME: Telegraher.9.33.17.
+            RNAME: Telegraher 9.33.18
+            TNAME: graher_9.33.18_
+            ANAME: Telegraher.9.33.18.
             AARCH: bundle

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ different)
 * Realeases are
   here: [https://github.com/nikitasius/Telegraher/releases](https://github.com/nikitasius/Telegraher/releases)
     * if it contain `beta` it mean it's BETA
-* Last release `9.33.16`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/graher_9.33.16_bundle)
+* Last release `9.33.18`: [bundle](https://github.com/nikitasius/Telegraher/releases/tag/graher_9.33.18_bundle)
 * Last beta: write `!beta` in chat
 
 ### Issues/Wishlist

--- a/README_CHANGES.md
+++ b/README_CHANGES.md
@@ -1,5 +1,16 @@
 # Changes
 
+* 9.33.18
+    * new OutOfMemory crash fix via foreground service (modded)
+    * disable emoji status for chats also (but need to debug more)
+    * extended admin rights to restrict gifs, stickers, games or inline bots for users in chat
+        * the idea and main code from @arsLan and his Cherrygram
+    * custom error messages if you got resticted for gifs only or stickers only
+        * actually i track well strickers forbidden and let you to use gifs, but if gifs are forbidden (but stickers are
+          allowed) you can use both (but gifs will not pass). Thats somewhere in the vanilla code i need to debug later.
+    * channels and groups have edit icon now, so you can list all members (if not hidden) and admins.
+        * the code which display admin numbers is from @arsLan, but i adapted it for channels only.
+    * added english & russian translations for new options
 * 9.33.17
     * fixed spoiler bug
         * it's because a features you can enable via settings :)

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -21511,7 +21511,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
         }
 
         int topChatPanelHeight;
-        if (showEmojiStatusReport != null) {
+        if (showEmojiStatusReport != null && !(MessagesController.getGlobalTelegraherSettings().getBoolean("GraheriumDisableEmojiStatus", false))) {
             emojiStatusSpamHint.setVisibility(View.VISIBLE);
             topViewSeparator1.setVisibility(View.VISIBLE);
             topViewSeparator2.setVisibility(View.VISIBLE);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatRightsEditActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatRightsEditActivity.java
@@ -136,6 +136,9 @@ public class ChatRightsEditActivity extends BaseFragment {
 
     private int sendMessagesRow;
     private int sendMediaRow;
+    private int sendGifsRow;
+    private int sendGamesRow;
+    private int useInlineBotRow;
     private int sendStickersRow;
     private int sendPollsRow;
     private int embedLinksRow;
@@ -709,7 +712,13 @@ public class ChatRightsEditActivity extends BaseFragment {
                     } else if (position == sendMediaRow) {
                         value = bannedRights.send_media = !bannedRights.send_media;
                     } else if (position == sendStickersRow) {
-                        value = bannedRights.send_stickers = bannedRights.send_games = bannedRights.send_gifs = bannedRights.send_inline = !bannedRights.send_stickers;
+                        value = bannedRights.send_stickers = !bannedRights.send_stickers;
+                    } else if (position == sendGifsRow) {
+                        value = bannedRights.send_gifs = !bannedRights.send_gifs;
+                    } else if (position == sendGamesRow) {
+                        value = bannedRights.send_games = !bannedRights.send_games;
+                    }else if (position == useInlineBotRow) {
+                        value = bannedRights.send_inline = !bannedRights.send_inline;
                     } else if (position == embedLinksRow) {
                         value = bannedRights.embed_links = !bannedRights.embed_links;
                     } else if (position == sendPollsRow) {
@@ -738,8 +747,29 @@ public class ChatRightsEditActivity extends BaseFragment {
                             }
                         }
                         if ((bannedRights.view_messages || bannedRights.send_messages) && !bannedRights.send_stickers) {
-                            bannedRights.send_stickers = bannedRights.send_games = bannedRights.send_gifs = bannedRights.send_inline = true;
+                            bannedRights.send_stickers = true;
                             RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(sendStickersRow);
+                            if (holder != null) {
+                                ((TextCheckCell2) holder.itemView).setChecked(false);
+                            }
+                        }
+                        if ((bannedRights.view_messages || bannedRights.send_messages) && !bannedRights.send_gifs) {
+                            bannedRights.send_gifs = true;
+                            RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(sendGifsRow);
+                            if (holder != null) {
+                                ((TextCheckCell2) holder.itemView).setChecked(false);
+                            }
+                        }
+                        if ((bannedRights.view_messages || bannedRights.send_messages) && !bannedRights.send_games) {
+                            bannedRights.send_games = true;
+                            RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(sendGamesRow);
+                            if (holder != null) {
+                                ((TextCheckCell2) holder.itemView).setChecked(false);
+                            }
+                        }
+                        if ((bannedRights.view_messages || bannedRights.send_messages) && !bannedRights.send_inline) {
+                            bannedRights.send_inline = true;
+                            RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(useInlineBotRow);
                             if (holder != null) {
                                 ((TextCheckCell2) holder.itemView).setChecked(false);
                             }
@@ -983,6 +1013,9 @@ public class ChatRightsEditActivity extends BaseFragment {
         sendMessagesRow = -1;
         sendMediaRow = -1;
         sendStickersRow = -1;
+        sendGifsRow = -1;
+        sendGamesRow = -1;
+        useInlineBotRow = -1;
         sendPollsRow = -1;
         embedLinksRow = -1;
         startVoiceChatRow = -1;
@@ -1022,6 +1055,9 @@ public class ChatRightsEditActivity extends BaseFragment {
             sendMessagesRow = rowCount++;
             sendMediaRow = rowCount++;
             sendStickersRow = rowCount++;
+            sendGifsRow = rowCount++;
+            sendGamesRow = rowCount++;
+            useInlineBotRow = rowCount++;
             sendPollsRow = rowCount++;
             embedLinksRow = rowCount++;
             addUsersRow = rowCount++;
@@ -1646,8 +1682,17 @@ public class ChatRightsEditActivity extends BaseFragment {
                         checkCell.setTextAndCheck(LocaleController.getString("UserRestrictionsSendMedia", R.string.UserRestrictionsSendMedia), !bannedRights.send_media && !defaultBannedRights.send_media, true);
                         checkCell.setIcon(defaultBannedRights.send_media ? R.drawable.permission_locked : 0);
                     } else if (position == sendStickersRow) {
-                        checkCell.setTextAndCheck(LocaleController.getString("UserRestrictionsSendStickers", R.string.UserRestrictionsSendStickers), !bannedRights.send_stickers && !defaultBannedRights.send_stickers, true);
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsSendStickers", R.string.THUserRestrictionsSendStickers), !bannedRights.send_stickers && !defaultBannedRights.send_stickers, true);
                         checkCell.setIcon(defaultBannedRights.send_stickers ? R.drawable.permission_locked : 0);
+                    } else if (position == sendGifsRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsSendGifs", R.string.THUserRestrictionsSendGifs), !bannedRights.send_gifs && !defaultBannedRights.send_gifs, true);
+                        checkCell.setIcon(defaultBannedRights.send_gifs ? R.drawable.permission_locked : 0);
+                    } else if (position == sendGamesRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsSendGames", R.string.THUserRestrictionsSendGames), !bannedRights.send_games && !defaultBannedRights.send_games, true);
+                        checkCell.setIcon(defaultBannedRights.send_games ? R.drawable.permission_locked : 0);
+                    } else if (position == useInlineBotRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsUseInlineBots", R.string.THUserRestrictionsUseInlineBots), !bannedRights.send_inline && !defaultBannedRights.send_inline, true);
+                        checkCell.setIcon(defaultBannedRights.send_inline ? R.drawable.permission_locked : 0);
                     } else if (position == embedLinksRow) {
                         checkCell.setTextAndCheck(LocaleController.getString("UserRestrictionsEmbedLinks", R.string.UserRestrictionsEmbedLinks), !bannedRights.embed_links && !defaultBannedRights.embed_links, true);
                         checkCell.setIcon(defaultBannedRights.embed_links ? R.drawable.permission_locked : 0);
@@ -1659,7 +1704,7 @@ public class ChatRightsEditActivity extends BaseFragment {
                     if (currentType == TYPE_ADD_BOT) {
 //                        checkCell.setEnabled((asAdmin || position == manageRow) && !checkCell.hasIcon(), false);
                     } else {
-                        if (position == sendMediaRow || position == sendStickersRow || position == embedLinksRow || position == sendPollsRow) {
+                        if (position == sendMediaRow || position == sendStickersRow || position == sendGifsRow || position == sendGamesRow || position == useInlineBotRow || position == embedLinksRow || position == sendPollsRow) {
                             checkCell.setEnabled(!bannedRights.send_messages && !bannedRights.view_messages && !defaultBannedRights.send_messages && !defaultBannedRights.view_messages);
                         } else if (position == sendMessagesRow) {
                             checkCell.setEnabled(!bannedRights.view_messages && !defaultBannedRights.view_messages);
@@ -1736,9 +1781,10 @@ public class ChatRightsEditActivity extends BaseFragment {
             } else if (position == 2 || position == rankHeaderRow) {
                 return VIEW_TYPE_HEADER_CELL;
             } else if (position == changeInfoRow || position == postMessagesRow || position == editMesagesRow || position == deleteMessagesRow ||
-                    position == addAdminsRow || position == banUsersRow || position == addUsersRow || position == pinMessagesRow ||
-                    position == sendMessagesRow || position == sendMediaRow || position == sendStickersRow || position == embedLinksRow ||
-                    position == sendPollsRow || position == anonymousRow || position == startVoiceChatRow || position == manageRow || position == manageTopicsRow) {
+                position == addAdminsRow || position == banUsersRow || position == addUsersRow || position == pinMessagesRow ||
+                position == sendMessagesRow || position == sendMediaRow || position == sendStickersRow || position == sendGifsRow ||
+                position == sendGamesRow || position == useInlineBotRow || position == embedLinksRow || position == sendPollsRow ||
+                position == anonymousRow || position == startVoiceChatRow || position == manageRow || position == manageTopicsRow) {
                 return VIEW_TYPE_SWITCH_CELL;
             } else if (position == cantEditInfoRow || position == rankInfoRow) {
                 return VIEW_TYPE_INFO_CELL;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatUsersActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatUsersActivity.java
@@ -114,6 +114,9 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
     private int sendMessagesRow;
     private int sendMediaRow;
     private int sendStickersRow;
+    private int sendGifsRow;
+    private int sendGamesRow;
+    private int useInlineBotRow;
     private int sendPollsRow;
     private int embedLinksRow;
     private int changeInfoRow;
@@ -262,6 +265,9 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
         sendMessagesRow = -1;
         sendMediaRow = -1;
         sendStickersRow = -1;
+        sendGifsRow = -1;
+        sendGamesRow = -1;
+        useInlineBotRow = -1;
         sendPollsRow = -1;
         embedLinksRow = -1;
         addUsersRow = -1;
@@ -289,6 +295,9 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
             sendMessagesRow = rowCount++;
             sendMediaRow = rowCount++;
             sendStickersRow = rowCount++;
+            sendGifsRow = rowCount++;
+            sendGamesRow = rowCount++;
+            useInlineBotRow = rowCount++;
             sendPollsRow = rowCount++;
             embedLinksRow = rowCount++;
             addUsersRow = rowCount++;
@@ -993,7 +1002,13 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
                         } else if (position == sendMediaRow) {
                             defaultBannedRights.send_media = !defaultBannedRights.send_media;
                         } else if (position == sendStickersRow) {
-                            defaultBannedRights.send_stickers = defaultBannedRights.send_games = defaultBannedRights.send_gifs = defaultBannedRights.send_inline = !defaultBannedRights.send_stickers;
+                            defaultBannedRights.send_stickers = !defaultBannedRights.send_stickers;
+                        } else if (position == sendGifsRow) {
+                            defaultBannedRights.send_gifs = !defaultBannedRights.send_gifs;
+                        } else if (position == sendGamesRow) {
+                            defaultBannedRights.send_games = !defaultBannedRights.send_games;
+                        } else if (position == useInlineBotRow) {
+                            defaultBannedRights.send_inline = !defaultBannedRights.send_inline;
                         } else if (position == embedLinksRow) {
                             defaultBannedRights.embed_links = !defaultBannedRights.embed_links;
                         } else if (position == sendPollsRow) {
@@ -1022,8 +1037,29 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
                                 }
                             }
                             if ((defaultBannedRights.view_messages || defaultBannedRights.send_messages) && !defaultBannedRights.send_stickers) {
-                                defaultBannedRights.send_stickers = defaultBannedRights.send_games = defaultBannedRights.send_gifs = defaultBannedRights.send_inline = true;
+                                defaultBannedRights.send_stickers = true;
                                 RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(sendStickersRow);
+                                if (holder != null) {
+                                    ((TextCheckCell2) holder.itemView).setChecked(false);
+                                }
+                            }
+                            if ((defaultBannedRights.view_messages || defaultBannedRights.send_messages) && !defaultBannedRights.send_gifs) {
+                                defaultBannedRights.send_gifs = true;
+                                RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(sendGifsRow);
+                                if (holder != null) {
+                                    ((TextCheckCell2) holder.itemView).setChecked(false);
+                                }
+                            }
+                            if ((defaultBannedRights.view_messages || defaultBannedRights.send_messages) && !defaultBannedRights.send_games) {
+                                defaultBannedRights.send_games = true;
+                                RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(sendGamesRow);
+                                if (holder != null) {
+                                    ((TextCheckCell2) holder.itemView).setChecked(false);
+                                }
+                            }
+                            if ((defaultBannedRights.view_messages || defaultBannedRights.send_messages) && !defaultBannedRights.send_inline) {
+                                defaultBannedRights.send_inline = true;
+                                RecyclerListView.ViewHolder holder = listView.findViewHolderForAdapterPosition(useInlineBotRow);
                                 if (holder != null) {
                                     ((TextCheckCell2) holder.itemView).setChecked(false);
                                 }
@@ -3289,7 +3325,13 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
                     } else if (position == sendMediaRow) {
                         checkCell.setTextAndCheck(LocaleController.getString("UserRestrictionsSendMedia", R.string.UserRestrictionsSendMedia), !defaultBannedRights.send_media, true);
                     } else if (position == sendStickersRow) {
-                        checkCell.setTextAndCheck(LocaleController.getString("UserRestrictionsSendStickers", R.string.UserRestrictionsSendStickers), !defaultBannedRights.send_stickers, true);
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsSendStickers", R.string.THUserRestrictionsSendStickers), !defaultBannedRights.send_stickers, true);
+                    } else if (position == sendGifsRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsSendGifs", R.string.THUserRestrictionsSendGifs), !defaultBannedRights.send_gifs, true);
+                    } else if (position == sendGamesRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsSendGames", R.string.THUserRestrictionsSendGames), !defaultBannedRights.send_games, true);
+                    } else if (position == useInlineBotRow) {
+                        checkCell.setTextAndCheck(LocaleController.getString("THUserRestrictionsUseInlineBots", R.string.THUserRestrictionsUseInlineBots), !defaultBannedRights.send_inline, true);
                     } else if (position == embedLinksRow) {
                         checkCell.setTextAndCheck(LocaleController.getString("UserRestrictionsEmbedLinks", R.string.UserRestrictionsEmbedLinks), !defaultBannedRights.embed_links, true);
                     } else if (position == sendPollsRow) {
@@ -3298,7 +3340,7 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
                         checkCell.setTextAndCheck(LocaleController.getString("CreateTopicsPermission", R.string.CreateTopicsPermission), !defaultBannedRights.manage_topics, false);
                     }
 
-                    if (position == sendMediaRow || position == sendStickersRow || position == embedLinksRow || position == sendPollsRow) {
+                    if (position == sendMediaRow || position == sendStickersRow || position == sendGifsRow || position == sendGamesRow || position == useInlineBotRow || position == embedLinksRow || position == sendPollsRow) {
                         checkCell.setEnabled(!defaultBannedRights.send_messages && !defaultBannedRights.view_messages);
                     } else if (position == sendMessagesRow) {
                         checkCell.setEnabled(!defaultBannedRights.view_messages);
@@ -3384,7 +3426,8 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
             } else if (position == removedUsersRow) {
                 return 6;
             } else if (position == changeInfoRow || position == addUsersRow || position == pinMessagesRow || position == sendMessagesRow ||
-                    position == sendMediaRow || position == sendStickersRow || position == embedLinksRow || position == sendPollsRow || position == manageTopicsRow) {
+                position == sendMediaRow || position == sendStickersRow || position == sendGifsRow || position == sendGamesRow ||
+                position == useInlineBotRow || position == embedLinksRow || position == sendPollsRow || position == manageTopicsRow) {
                 return 7;
             } else if (position == membersHeaderRow || position == contactsHeaderRow || position == botHeaderRow || position == loadingHeaderRow) {
                 return 8;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ForegroundDetector.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ForegroundDetector.java
@@ -27,6 +27,7 @@ public class ForegroundDetector implements Application.ActivityLifecycleCallback
     }
 
     private int refs;
+    private boolean isPaused;
     private boolean wasInBackground = true;
     private long enterBackgroundTime = 0;
     private CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
@@ -111,10 +112,16 @@ public class ForegroundDetector implements Application.ActivityLifecycleCallback
 
     @Override
     public void onActivityResumed(Activity activity) {
+        this.isPaused =false;
     }
 
     @Override
     public void onActivityPaused(Activity activity) {
+        this.isPaused =true;
+    }
+
+    public boolean isPaused(){
+        return this.isPaused;
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/spoilers/SpoilerEffect.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/spoilers/SpoilerEffect.java
@@ -41,6 +41,7 @@ import androidx.core.math.MathUtils;
 import org.telegram.messenger.*;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.Easings;
+import org.telegram.ui.Components.ForegroundDetector;
 import org.telegram.ui.Components.TextStyleSpan;
 
 import java.util.ArrayList;
@@ -522,10 +523,12 @@ public class SpoilerEffect extends Drawable {
      * @return Measured key points
      */
     public static synchronized List<Long> measureKeyPoints(Layout textLayout) {
+        if (ForegroundDetector.getInstance().isPaused()) return Collections.emptyList();
+
         int w = textLayout.getWidth();
         int h = textLayout.getHeight();
 
-        if (w <= 0 || h <= 0 || w > 16384) //fix bitch
+        if (w <= 0 || h <= 0)
             return Collections.emptyList();
 
         Bitmap measureBitmap = Bitmap.createBitmap(Math.round(w), Math.round(h), Bitmap.Config.ARGB_4444); // We can use 4444 as we don't need accuracy here

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -7858,15 +7858,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                 createAutoDeleteItem(context);
             }
             if (ChatObject.isChannel(chat)) {
-                if (isTopic) {
-                    if (ChatObject.canManageTopic(currentAccount, chat, topicId)) {
-                        editItemVisible = true;
-                    }
-                } else {
-                    if (ChatObject.hasAdminRights(chat) || chat.megagroup && ChatObject.canChangeChatInfo(chat)) {
-                        editItemVisible = true;
-                    }
-                }
+                editItemVisible = true;
                 if (chatInfo != null) {
                     if (ChatObject.canManageCalls(chat) && chatInfo.call == null) {
                         otherItem.addSubItem(call_item, R.drawable.msg_voicechat, chat.megagroup && !chat.gigagroup ? LocaleController.getString("StartVoipChat", R.string.StartVoipChat) : LocaleController.getString("StartVoipChannel", R.string.StartVoipChannel));
@@ -7909,9 +7901,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                     ChatObject.Call call = getMessagesController().getGroupCall(chatId, false);
                     callItemVisible = call != null;
                 }
-                if (ChatObject.canChangeChatInfo(chat)) {
-                    editItemVisible = true;
-                }
+                editItemVisible = true;
                 if (!ChatObject.isKickedFromChat(chat) && !ChatObject.isLeftFromChat(chat)) {
                     if (chatInfo == null || !chatInfo.participants_hidden || ChatObject.hasAdminRights(chat)) {
                         canSearchMembers = true;

--- a/TMessagesProj/src/main/res/values-ru/strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/strings.xml
@@ -112,4 +112,8 @@
     <string name="THChatHideStickers">Скрывать стикеры в чатах</string>
     <string name="THPhotoMaxSize">Максимальный размер фото</string>
     <string name="THGraheriumDisableEmojiStatus">Убрать emoji из статуса</string>
+    <string name="THUserRestrictionsSendStickers">Отправка Стикеров</string>
+    <string name="THUserRestrictionsSendGifs">Отправк Гифок</string>
+    <string name="THUserRestrictionsSendGames">Отправка Игр</string>
+    <string name="THUserRestrictionsUseInlineBots">Использование Инлайн-Ботов</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -6159,4 +6159,8 @@
     <string name="THChatHideStickers">Hide stickers in chats</string>
     <string name="THPhotoMaxSize">Max photo size</string>
     <string name="THGraheriumDisableEmojiStatus">Disable emoji status</string>
+    <string name="THUserRestrictionsSendStickers">Send Stickers</string>
+    <string name="THUserRestrictionsSendGifs">Send GIFs</string>
+    <string name="THUserRestrictionsSendGames">Send Games</string>
+    <string name="THUserRestrictionsUseInlineBots">Use Inline Bots</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Sat Mar 12 05:53:50 MSK 2016
-APP_VERSION_NAME=9.33.17
-APP_VERSION_CODE=3026017
+APP_VERSION_NAME=9.33.18
+APP_VERSION_CODE=3026018
 APP_PACKAGE=com.evildayz.code.telegraher2
 RELEASE_KEY_PASSWORD=android
 RELEASE_KEY_ALIAS=androidkey


### PR DESCRIPTION
* new OutOfMemory crash fix via foreground service (modded)
* disable emoji status for chats also (but need to debug more)
* extended admin rights to restrict gifs, stickers, games or inline bots for users in chat
  * the idea and main code from @arsLan and his Cherrygram
* custom error messages if you got resticted for gifs only or stickers only
  * actually i track well strickers forbidden and let you to use gifs, but if gifs are forbidden (but stickers are allowed) you can use both (but gifs will not pass). Thats somewhere in the vanilla code i need to debug later.
* channels and groups have edit icon now, so you can list all members (if not hidden) and admins.
  * the code which display admin numbers is from @arsLan, but i adapted it for channels only.
* added english & russian translations for new options